### PR TITLE
Fix cursor jumping by caching target cursor positions correctly.

### DIFF
--- a/src/bin/pure.rs
+++ b/src/bin/pure.rs
@@ -158,6 +158,7 @@ fn run_app<B: ratatui::backend::Backend>(terminal: &mut Terminal<B>, app: &mut A
         // Block waiting for events
         if event::poll(timeout).context("event poll failed")? {
             let evt = event::read().context("failed to read event")?;
+            eprintln!("Event: {:?}", evt);
 
             // Skip spurious Resize events that don't change size
             if let Event::Resize(_, _) = evt {


### PR DESCRIPTION
This PR fixes jumping cursor behavior by correctly caching (and rebuilding) cursor positions during rendering.

Also, the "preferred horizontal position" when moving the cursor vertically is now the content column, not the visual column. This is more in line with other software and feels more natural.