### PR TITLE
Fix mouse positioning

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -402,9 +402,9 @@ For each paragraph:
    - Calculates target visual line: `scroll_top + (row - text_area.y)`
 
 2. **Find Nearest Position**:
-   - Calls `closest_pointer_near_line(visual_line, relative_column)`
-   - Searches `visual_positions` for entries on that line
-   - Finds closest position by column distance
+   - Calls `closest_pointer_near_line_visual(visual_line, relative_column)`
+   - Checks whether the click lands inside a reveal tag's visual width and, if so, selects that tag's pointer directly
+   - Otherwise searches `visual_positions` for entries on that line and finds the closest position by column distance
    - If line empty, searches nearby lines (alternating above/below)
    - Returns `CursorDisplay` with pointer and position
 
@@ -437,7 +437,7 @@ For each paragraph:
 
 3. **Render with Tags**: `display.render_document(...)`
    - Passes reveal tags to renderer
-   - Renderer inserts reveal tag fragments (e.g., `[Bold>`, `<Bold]`)
+   - Renderer inserts reveal tag fragments (e.g., `[Bold>`, `<Bold]`) and attaches marker events so hit-testing can target them
    - Tags styled distinctly (yellow on blue background)
    - Cursor can be positioned at tag boundaries
    - Tags have zero `content_width` (don't affect content column tracking)

--- a/src/render.rs
+++ b/src/render.rs
@@ -711,13 +711,46 @@ impl<'a> DirectRenderer<'a> {
             let display = reveal_tag_display(span.style, RevealTagKind::Start);
             let tag_style = self.theme.reveal_tag_style();
             let width = visible_width(&display);
+
+            // Track position for the reveal start tag so it can be clicked
+            let direct_events = self.check_position_match(
+                span_path,
+                0, // offset at start of span
+                SegmentKind::RevealStart(span.style),
+            );
+
+            // Convert DirectTextEvents to TextEvents
+            let events: Vec<TextEvent> = direct_events
+                .iter()
+                .map(|e| {
+                    let kind = match e.kind {
+                        DirectTextEventKind::Cursor => TextEventKind::Cursor,
+                        DirectTextEventKind::SelectionStart => TextEventKind::SelectionStart,
+                        DirectTextEventKind::SelectionEnd => TextEventKind::SelectionEnd,
+                        DirectTextEventKind::Position => {
+                            let marker_id = self.next_marker_id;
+                            self.next_marker_id += 1;
+                            self.marker_to_pointer.insert(marker_id, e.pointer.clone());
+                            TextEventKind::Marker(marker_id)
+                        }
+                    };
+                    TextEvent {
+                        offset: e.offset,
+                        content_offset: e.content_offset,
+                        offset_hint: None,
+                        content_offset_hint: None,
+                        kind,
+                    }
+                })
+                .collect();
+
             fragments.push(FragmentItem::Token(Fragment {
                 text: display,
                 style: tag_style,
                 kind: FragmentKind::RevealTag,
                 width,
                 content_width: 0,
-                events: Vec::new(),
+                events,
                 reveal_kind: Some(RevealTagKind::Start),
             }));
         }
@@ -759,13 +792,48 @@ impl<'a> DirectRenderer<'a> {
             let display = reveal_tag_display(span.style, RevealTagKind::End);
             let tag_style = self.theme.reveal_tag_style();
             let width = visible_width(&display);
+
+            // Track position for the reveal end tag so it can be clicked
+            // The reveal end is at the end of the span text
+            let end_offset = span.text.chars().count();
+            let direct_events = self.check_position_match(
+                span_path,
+                end_offset,
+                SegmentKind::RevealEnd(span.style),
+            );
+
+            // Convert DirectTextEvents to TextEvents
+            let events: Vec<TextEvent> = direct_events
+                .iter()
+                .map(|e| {
+                    let kind = match e.kind {
+                        DirectTextEventKind::Cursor => TextEventKind::Cursor,
+                        DirectTextEventKind::SelectionStart => TextEventKind::SelectionStart,
+                        DirectTextEventKind::SelectionEnd => TextEventKind::SelectionEnd,
+                        DirectTextEventKind::Position => {
+                            let marker_id = self.next_marker_id;
+                            self.next_marker_id += 1;
+                            self.marker_to_pointer.insert(marker_id, e.pointer.clone());
+                            TextEventKind::Marker(marker_id)
+                        }
+                    };
+                    TextEvent {
+                        offset: e.offset,
+                        content_offset: e.content_offset,
+                        offset_hint: None,
+                        content_offset_hint: None,
+                        kind,
+                    }
+                })
+                .collect();
+
             fragments.push(FragmentItem::Token(Fragment {
                 text: display,
                 style: tag_style,
                 kind: FragmentKind::RevealTag,
                 width,
                 content_width: 0,
-                events: Vec::new(),
+                events,
                 reveal_kind: Some(RevealTagKind::End),
             }));
         }
@@ -2278,7 +2346,8 @@ mod tests {
         // cursor.column INCLUDES left_padding in its value
         // So with left_padding=4, the column should be 4 more than with left_padding=0
         assert_eq!(
-            cursor4.column, cursor0.column + 4,
+            cursor4.column,
+            cursor0.column + 4,
             "cursor.column should include the left_padding offset"
         );
 


### PR DESCRIPTION
This PR fixes positioning the cursor using mouse clicks when:
- there's a left padding
- selecting an indented paragraph or checklist
- clicking on "Reveal Codes" tags