### PR TITLE
Fix reveal codes bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,121 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+While pre-1.0, the minor version is bumped for breaking changes.
+
+<!-- next-header -->
+
+## [Unreleased] - ReleaseDate
+
+### Added
+
+- A menu bar in the typical TUI style: File, Edit, Format, and View menus
+  across the top of the screen, opened with F10 or an Alt+letter accelerator
+  and driven with the keyboard. (#29)
+- Basic undo/redo support (Ctrl+Z / Ctrl+Y). Consecutive typing, deleting, and
+  backspacing coalesce into single undo steps. (#26)
+- An SVG snapshot testing harness: tests drive the real application headlessly
+  through synthetic key and mouse events and snapshot the rendered terminal as
+  deterministic SVG, so styling, selection, and cursor placement diff as text
+  and open in any browser. (#27)
+
+### Fixed
+
+- Applying an inline style to a selection no longer makes the cursor jump to
+  the beginning of the selection; it stays at the position it had before. (#28)
+- With reveal codes shown, pressing Backspace directly behind a start tag like
+  `[Italic>` removes the formatting again instead of merging the paragraph
+  into the previous one, and the cursor stays at the position of the removed
+  tag. The same root cause made Backspace at a style-span boundary merge
+  paragraphs with reveal codes hidden, too. (#28)
+- Inserting or deleting a character in a line that shows reveal codes later in
+  the line no longer hides those codes (while keeping the formatting) until
+  the next full re-render. (#28)
+
+## [0.4.2] - 2026-03-01
+
+### Fixed
+
+- Cursor movement around reveal-code tags.
+
+## [0.4.1] - 2026-02-28
+
+### Changed
+
+- Upgraded tdoc without its remote feature, dropping the SSL dependencies.
+
+## [0.4.0] - 2026-01-11
+
+### Changed
+
+- Upgraded tdoc for transparent Markdown frontmatter support and a Markdown
+  code block fix.
+
+## [0.3.0] - 2025-12-03
+
+### Added
+
+- Support for selections spanning multiple paragraphs. (#21)
+
+### Changed
+
+- Improved styling of headers and nested lists. (#22)
+- Improved default colors: highlights, selection, scrollbar, and the menus'
+  structural characters. (#17)
+- The cursor is a blinking underscore while a selection is active. (#16)
+
+### Fixed
+
+- Coloring of structural characters in nested quotes. (#20)
+- Rendering of indented checklists. (#19)
+- Cursor positioning with mouse clicks. (#18)
+
+## [0.2.2] - 2025-11-29
+
+### Changed
+
+- Improved mouse selection speed and accuracy. (#15)
+
+### Fixed
+
+- Setting paragraph types that involve structural changes. (#14)
+
+## [0.2.1] - 2025-11-29
+
+### Fixed
+
+- Joining and splitting paragraphs. (#12)
+
+## [0.2.0] - 2025-11-28
+
+### Added
+
+- New scrollbar implementation. (#5)
+
+### Changed
+
+- Refactored the layouting algorithm for incremental updates and improved
+  cursor and selection tracking. (#11)
+- Improved status bar styling. (#6)
+
+### Fixed
+
+- Cursor jumping, by caching target cursor positions correctly. (#4)
+
+## [0.1.0] - 2025-11-25
+
+Initial release.
+
+<!-- next-url -->
+[Unreleased]: https://github.com/roblillack/pure/compare/v0.4.2...HEAD
+[0.4.2]: https://github.com/roblillack/pure/compare/v0.4.1...v0.4.2
+[0.4.1]: https://github.com/roblillack/pure/compare/v0.4.0...v0.4.1
+[0.4.0]: https://github.com/roblillack/pure/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/roblillack/pure/compare/v0.2.2...v0.3.0
+[0.2.2]: https://github.com/roblillack/pure/compare/v0.2.1...v0.2.2
+[0.2.1]: https://github.com/roblillack/pure/compare/v0.2.0...v0.2.1
+[0.2.0]: https://github.com/roblillack/pure/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/roblillack/pure/releases/tag/v0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,20 @@ license = "MIT"
 readme = "README.md"
 repository = "https://github.com/roblillack/pure"
 
+[package.metadata.release]
+pre-release-replacements = [
+    # Roll CHANGELOG's [Unreleased] over to the new version and re-seed a fresh
+    # [Unreleased] above it (the Keep a Changelog + cargo-release marker idiom).
+    # Order matters: the version/date/compare substitutions run first, *then*
+    # the markers re-insert the literal "Unreleased"/"ReleaseDate" tokens so the
+    # next release finds them again.
+    { file = "CHANGELOG.md", search = "Unreleased", replace = "{{version}}" },
+    { file = "CHANGELOG.md", search = '\.\.\.HEAD', replace = "...{{tag_name}}", exactly = 1 },
+    { file = "CHANGELOG.md", search = "ReleaseDate", replace = "{{date}}" },
+    { file = "CHANGELOG.md", search = "<!-- next-header -->", replace = "<!-- next-header -->\n\n## [Unreleased] - ReleaseDate", exactly = 1 },
+    { file = "CHANGELOG.md", search = "<!-- next-url -->", replace = "<!-- next-url -->\n[Unreleased]: https://github.com/roblillack/pure/compare/{{tag_name}}...HEAD", exactly = 1 },
+]
+
 [dependencies]
 anyhow = "1.0"
 crossterm = "0.29.0"

--- a/src/app.rs
+++ b/src/app.rs
@@ -625,7 +625,6 @@ impl App {
             self.mark_dirty();
             self.display.set_preferred_column(None);
             self.selection_anchor = None;
-            let _ = self.display.move_to_pointer(&selection.1);
             true
         } else {
             false

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -476,6 +476,22 @@ impl DocumentEditor {
         self.rebuild_segments();
     }
 
+    /// Reveal tag references for all reveal segments, in document order.
+    /// Produces the same tags as `clone_with_markers` without cloning the
+    /// document.
+    pub fn reveal_tag_refs(&self) -> Vec<RevealTagRef> {
+        self.segments
+            .iter()
+            .filter_map(|segment| match segment.kind {
+                SegmentKind::RevealStart(style) => Some((style, RevealTagKind::Start)),
+                SegmentKind::RevealEnd(style) => Some((style, RevealTagKind::End)),
+                SegmentKind::Text => None,
+            })
+            .enumerate()
+            .map(|(id, (style, kind))| RevealTagRef { id, style, kind })
+            .collect()
+    }
+
     pub fn clone_with_markers(
         &self,
         cursor_sentinel: char,

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -1361,13 +1361,11 @@ impl DocumentEditor {
         if let Some(segment) = self.segments.get(self.cursor_segment)
             && segment.kind != SegmentKind::Text
         {
-            if let Some(target_pointer) = self.remove_reveal_tag_segment(self.cursor_segment) {
+            if let Some((paragraph_path, char_offset)) =
+                self.remove_reveal_tag_segment(self.cursor_segment)
+            {
                 self.rebuild_segments();
-                if !self.move_to_pointer(&target_pointer)
-                    && !self.fallback_move_to_text(&target_pointer, false)
-                {
-                    self.ensure_cursor_selectable();
-                }
+                self.move_to_paragraph_char_offset(&paragraph_path, char_offset);
                 return true;
             } else {
                 return false;
@@ -1564,6 +1562,45 @@ impl DocumentEditor {
         true
     }
 
+    /// Character offset of a pointer within its paragraph, counting only text
+    /// segments. Survives span restructuring, unlike span paths.
+    pub(crate) fn paragraph_char_offset_of_pointer(
+        &self,
+        pointer: &CursorPointer,
+    ) -> Option<usize> {
+        let index = self
+            .segments
+            .iter()
+            .position(|segment| segment.matches_pointer(pointer))?;
+        let mut char_offset: usize = self.segments[..index]
+            .iter()
+            .filter(|segment| {
+                segment.paragraph_path == pointer.paragraph_path
+                    && matches!(segment.kind, SegmentKind::Text)
+            })
+            .map(|segment| segment.len)
+            .sum();
+        let segment = &self.segments[index];
+        if matches!(segment.kind, SegmentKind::Text) {
+            char_offset += pointer.offset.min(segment.len);
+        }
+        Some(char_offset)
+    }
+
+    pub(crate) fn move_to_paragraph_char_offset(
+        &mut self,
+        path: &ParagraphPath,
+        char_offset: usize,
+    ) {
+        if let Some(pointer) = self.pointer_at_paragraph_char_offset(path, char_offset) {
+            if !self.move_to_pointer(&pointer) && !self.fallback_move_to_text(&pointer, false) {
+                self.ensure_cursor_selectable();
+            }
+        } else {
+            self.ensure_cursor_selectable();
+        }
+    }
+
     fn pointer_at_paragraph_char_offset(
         &self,
         path: &ParagraphPath,
@@ -1598,6 +1635,21 @@ impl DocumentEditor {
             Some(segment) => segment.clone(),
             None => return false,
         };
+
+        // Only merge when the cursor sits at the very start of its paragraph:
+        // any non-empty segment before it in the same paragraph (text, or a
+        // reveal-codes tag) means backspace edits within the paragraph instead.
+        let mut idx = self.cursor_segment;
+        while idx > 0 {
+            idx -= 1;
+            let segment = &self.segments[idx];
+            if segment.paragraph_path != current_segment.paragraph_path {
+                break;
+            }
+            if segment.len > 0 {
+                return false;
+            }
+        }
 
         // Find the previous text segment in a different paragraph
         let mut prev_segment_idx = self.cursor_segment;
@@ -2201,13 +2253,11 @@ impl DocumentEditor {
         let current_len = self.current_segment_len();
         if self.cursor.offset < current_len {
             if self.cursor.segment_kind != SegmentKind::Text {
-                if let Some(target_pointer) = self.remove_reveal_tag_segment(self.cursor_segment) {
+                if let Some((paragraph_path, char_offset)) =
+                    self.remove_reveal_tag_segment(self.cursor_segment)
+                {
                     self.rebuild_segments();
-                    if !self.move_to_pointer(&target_pointer)
-                        && !self.fallback_move_to_text(&target_pointer, false)
-                    {
-                        self.ensure_cursor_selectable();
-                    }
+                    self.move_to_paragraph_char_offset(&paragraph_path, char_offset);
                     return true;
                 } else {
                     return false;
@@ -2230,13 +2280,11 @@ impl DocumentEditor {
 
         let next_segment = &self.segments[self.cursor_segment + 1];
         if next_segment.kind != SegmentKind::Text {
-            if let Some(target_pointer) = self.remove_reveal_tag_segment(self.cursor_segment + 1) {
+            if let Some((paragraph_path, char_offset)) =
+                self.remove_reveal_tag_segment(self.cursor_segment + 1)
+            {
                 self.rebuild_segments();
-                if !self.move_to_pointer(&target_pointer)
-                    && !self.fallback_move_to_text(&target_pointer, false)
-                {
-                    self.ensure_cursor_selectable();
-                }
+                self.move_to_paragraph_char_offset(&paragraph_path, char_offset);
                 return true;
             } else {
                 return false;
@@ -2370,12 +2418,27 @@ impl DocumentEditor {
         removed
     }
 
-    fn remove_reveal_tag_segment(&mut self, segment_index: usize) -> Option<CursorPointer> {
+    /// Remove the style behind a reveal tag segment. Returns the paragraph
+    /// path and the character offset the tag occupied, so the caller can
+    /// restore the cursor after the spans have been restructured (span paths
+    /// are not stable across `prune_and_merge_spans`).
+    fn remove_reveal_tag_segment(
+        &mut self,
+        segment_index: usize,
+    ) -> Option<(ParagraphPath, usize)> {
         let segment = self.segments.get(segment_index)?.clone();
         let style = match segment.kind {
             SegmentKind::RevealStart(style) | SegmentKind::RevealEnd(style) => style,
             SegmentKind::Text => return None,
         };
+        let char_offset: usize = self.segments[..segment_index]
+            .iter()
+            .filter(|other| {
+                other.paragraph_path == segment.paragraph_path
+                    && matches!(other.kind, SegmentKind::Text)
+            })
+            .map(|other| other.len)
+            .sum();
         let paragraph = paragraph_mut(&mut self.document, &segment.paragraph_path)?;
         let span = span_mut(paragraph, &segment.span_path)?;
         if span.style != style {
@@ -2384,19 +2447,8 @@ impl DocumentEditor {
         }
         span.style = InlineStyle::None;
         span.link_target = None;
-        let span_len = span.text.chars().count();
         prune_and_merge_spans(paragraph.content_mut());
-        let offset = match segment.kind {
-            SegmentKind::RevealStart(_) => 0,
-            SegmentKind::RevealEnd(_) => span_len,
-            SegmentKind::Text => span_len,
-        };
-        Some(CursorPointer {
-            paragraph_path: segment.paragraph_path,
-            span_path: segment.span_path,
-            offset,
-            segment_kind: SegmentKind::Text,
-        })
+        Some((segment.paragraph_path, char_offset))
     }
 
     fn current_paragraph_is_empty(&self) -> bool {

--- a/src/editor/style_tests.rs
+++ b/src/editor/style_tests.rs
@@ -130,3 +130,32 @@ fn apply_inline_style_in_checklist_item() {
     assert_eq!(item.content[1].text, " tea");
     assert_eq!(item.content[1].style, InlineStyle::None);
 }
+
+#[test]
+fn apply_inline_style_keeps_cursor_position() {
+    let document = Document::new().with_paragraphs(vec![text_paragraph(
+        "Pure is a modern, terminal-based word processor for your terminal",
+    )]);
+    let mut editor = DocumentEditor::new(document);
+
+    // Select "terminal-based word processor" (chars 18..47) with the cursor
+    // sitting at the selection end, like after shift-selecting forward.
+    let mut start = pointer_to_root_span(0);
+    start.offset = 18;
+    let mut end = pointer_to_root_span(0);
+    end.offset = 47;
+    assert!(editor.move_to_pointer(&end));
+
+    assert!(editor.apply_inline_style_to_selection(&(start, end), InlineStyle::Italic));
+
+    let cursor = editor.cursor_pointer();
+    assert_eq!(
+        cursor.span_path.indices(),
+        &[1],
+        "cursor should stay on the newly styled span"
+    );
+    assert_eq!(
+        cursor.offset, 29,
+        "cursor should stay at the end of the styled text"
+    );
+}

--- a/src/editor/styles.rs
+++ b/src/editor/styles.rs
@@ -45,6 +45,13 @@ impl DocumentEditor {
             return false;
         }
 
+        // Applying a style splits and merges spans, invalidating span paths.
+        // Remember the cursor as a character offset so it can be restored at
+        // the same document position afterwards.
+        let cursor_position = self
+            .paragraph_char_offset_of_pointer(&self.cursor)
+            .map(|char_offset| (self.cursor.paragraph_path.clone(), char_offset));
+
         let segments_snapshot = self.segments.clone();
         let mut changed = false;
         let mut touched_paragraphs: Vec<ParagraphPath> = Vec::new();
@@ -128,6 +135,10 @@ impl DocumentEditor {
                 // Multiple root paragraphs affected: fall back to full rebuild for simplicity
                 // (Could be optimized further to update each root incrementally)
                 self.rebuild_segments();
+            }
+
+            if let Some((paragraph_path, char_offset)) = cursor_position {
+                self.move_to_paragraph_char_offset(&paragraph_path, char_offset);
             }
         }
 

--- a/src/editor_display.rs
+++ b/src/editor_display.rs
@@ -246,10 +246,7 @@ impl EditorDisplay {
 
         // Get reveal tags if in reveal codes mode
         let reveal_tags = if self.editor.reveal_codes() {
-            let (_, _, tags, _) = self
-                .editor
-                .clone_with_markers('\u{F8FF}', None, '\u{F8FE}', '\u{F8FD}');
-            tags
+            self.editor.reveal_tag_refs()
         } else {
             Vec::new()
         };
@@ -473,9 +470,14 @@ impl EditorDisplay {
         let old_end_line = para_info.end_line;
         let old_line_count = old_end_line - old_start_line + 1;
 
-        // Skip reveal tags for incremental updates to avoid expensive document clone
-        // Reveal codes will be updated on the next full render
-        let reveal_tags = Vec::new();
+        // Keep reveal tags in the incrementally updated layout; the cached
+        // layout persists, so dropping them here would hide the codes until
+        // the next full render.
+        let reveal_tags = if self.editor.reveal_codes() {
+            self.editor.reveal_tag_refs()
+        } else {
+            Vec::new()
+        };
 
         // Layout the paragraph
         let cursor_pointer = self.editor.cursor_pointer();
@@ -658,13 +660,8 @@ impl EditorDisplay {
         let cursor_pointer = self.editor.cursor_pointer();
 
         // Get reveal tags for reveal codes mode
-        // TODO: Optimize this - we currently need to call clone_with_markers just for reveal_tags
-        // In the future, extract reveal tag generation into a separate non-cloning function
         let reveal_tags = if self.editor.reveal_codes() {
-            let (_, _, tags, _) = self
-                .editor
-                .clone_with_markers('\u{F8FF}', None, '\u{F8FE}', '\u{F8FD}');
-            tags
+            self.editor.reveal_tag_refs()
         } else {
             Vec::new()
         };

--- a/src/editor_tests.rs
+++ b/src/editor_tests.rs
@@ -3244,3 +3244,67 @@ fn split_nested_checkbox_item_moves_children_to_new_item() {
         "Second nested child should be preserved"
     );
 }
+
+#[test]
+fn backspace_after_reveal_start_tag_removes_style_without_merging_paragraphs() {
+    let mut styled = Span::new_text("terminal-based word processor");
+    styled.style = InlineStyle::Italic;
+    let second = Paragraph::new_text().with_content(vec![
+        Span::new_text("Pure is a modern, "),
+        styled,
+        Span::new_text(" for structured documents."),
+    ]);
+    let document = Document::new().with_paragraphs(vec![text_paragraph("Intro paragraph"), second]);
+    let mut editor = DocumentEditor::new(document);
+    editor.set_reveal_codes(true);
+
+    // Place the cursor between `[Italic>` and "terminal-based…".
+    let mut pointer = pointer_to_root_span(1);
+    pointer.span_path = SpanPath::new(vec![1]);
+    assert!(editor.move_to_pointer(&pointer));
+
+    assert!(editor.backspace());
+
+    let doc = editor.document();
+    assert_eq!(doc.paragraphs.len(), 2, "paragraphs must not be merged");
+    assert_eq!(doc.paragraphs[0].content()[0].text, "Intro paragraph");
+    let spans = doc.paragraphs[1].content();
+    assert_eq!(spans.len(), 1, "removing the style should merge the spans");
+    assert_eq!(spans[0].style, InlineStyle::None);
+    assert_eq!(
+        spans[0].text,
+        "Pure is a modern, terminal-based word processor for structured documents."
+    );
+
+    // The cursor should stay where the start tag was removed.
+    let cursor = editor.cursor_pointer();
+    assert_eq!(cursor.paragraph_path, ParagraphPath::new_root(1));
+    assert_eq!(cursor.offset, 18);
+}
+
+#[test]
+fn backspace_at_styled_span_start_deletes_previous_character() {
+    let mut styled = Span::new_text("styled");
+    styled.style = InlineStyle::Bold;
+    let second = Paragraph::new_text().with_content(vec![
+        Span::new_text("Some "),
+        styled,
+        Span::new_text(" text"),
+    ]);
+    let document = Document::new().with_paragraphs(vec![text_paragraph("Intro"), second]);
+    let mut editor = DocumentEditor::new(document);
+
+    // Cursor at offset 0 of the styled span, i.e. between "Some " and "styled".
+    let mut pointer = pointer_to_root_span(1);
+    pointer.span_path = SpanPath::new(vec![1]);
+    assert!(editor.move_to_pointer(&pointer));
+
+    assert!(editor.backspace());
+
+    let doc = editor.document();
+    assert_eq!(doc.paragraphs.len(), 2, "paragraphs must not be merged");
+    let spans = doc.paragraphs[1].content();
+    assert_eq!(spans[0].text, "Some");
+    assert_eq!(spans[1].text, "styled");
+    assert_eq!(spans[1].style, InlineStyle::Bold);
+}

--- a/src/snapshot_tests.rs
+++ b/src/snapshot_tests.rs
@@ -193,6 +193,41 @@ fn inline_style_keeps_cursor_and_backspace_after_reveal_tag_removes_style() {
 }
 
 #[test]
+fn editing_keeps_reveal_codes_visible() {
+    let document = ftml! {
+        p { "Pure is a modern, " i { "terminal-based word processor" } "." }
+    };
+    let mut app = TestApp::new(WIDTH, HEIGHT, document);
+
+    // Enable reveal codes via the View menu.
+    app.key_with(KeyCode::Char('v'), KeyModifiers::ALT);
+    app.key(KeyCode::Enter);
+    assert!(
+        app.svg().contains("[Italic&gt;"),
+        "reveal tags should be visible after enabling reveal codes"
+    );
+
+    // Delete the space after "Pure" with backspace; the reveal tags later in
+    // the line must stay visible.
+    for _ in 0..5 {
+        app.key(KeyCode::Right);
+    }
+    app.key(KeyCode::Backspace);
+    assert!(
+        app.svg().contains("[Italic&gt;"),
+        "reveal tags must stay visible after deleting a character"
+    );
+
+    // Same when typing the space back in.
+    app.key(KeyCode::Char(' '));
+    assert!(
+        app.svg().contains("[Italic&gt;"),
+        "reveal tags must stay visible after inserting a character"
+    );
+    assert_svg("editing_keeps_reveal_codes_visible", &mut app);
+}
+
+#[test]
 fn menu_format_opens_formatting_menu() {
     let mut app = sample_app();
     app.key(KeyCode::F(10));

--- a/src/snapshot_tests.rs
+++ b/src/snapshot_tests.rs
@@ -158,6 +158,41 @@ fn menu_view_toggles_reveal_codes() {
 }
 
 #[test]
+fn inline_style_keeps_cursor_and_backspace_after_reveal_tag_removes_style() {
+    let document = ftml! {
+        p { "Intro paragraph." }
+        p { "Pure is a modern, terminal-based word processor." }
+    };
+    let mut app = TestApp::new(WIDTH, HEIGHT, document);
+
+    // Select "terminal-based word processor" in the second paragraph.
+    app.key(KeyCode::Down);
+    for _ in 0..18 {
+        app.key(KeyCode::Right);
+    }
+    for _ in 0..29 {
+        app.key_with(KeyCode::Right, KeyModifiers::SHIFT);
+    }
+
+    // Apply italic via the context menu; the cursor must stay at the end of
+    // the styled text instead of jumping to the start of the selection.
+    app.key(KeyCode::Esc);
+    app.key(KeyCode::Char('i'));
+    assert_svg("italic_keeps_cursor_at_selection_end", &mut app);
+
+    // Enable reveal codes, move the cursor right behind the `[Italic>` tag
+    // and press backspace: the style is removed, the paragraphs stay intact,
+    // and the cursor stays at the position of the removed tag.
+    app.key_with(KeyCode::Char('v'), KeyModifiers::ALT);
+    app.key(KeyCode::Enter);
+    for _ in 0..29 {
+        app.key(KeyCode::Left);
+    }
+    app.key(KeyCode::Backspace);
+    assert_svg("backspace_after_reveal_tag_removes_style", &mut app);
+}
+
+#[test]
 fn menu_format_opens_formatting_menu() {
     let mut app = sample_app();
     app.key(KeyCode::F(10));

--- a/src/snapshots/backspace_after_reveal_tag_removes_style.snap
+++ b/src/snapshots/backspace_after_reveal_tag_removes_style.snap
@@ -1,0 +1,5 @@
+---
+source: src/snapshot_tests.rs
+extension: svg
+snapshot_kind: binary
+---

--- a/src/snapshots/backspace_after_reveal_tag_removes_style.snap.svg
+++ b/src/snapshots/backspace_after_reveal_tag_removes_style.snap.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="360" viewBox="0 0 720 360" font-family="'DejaVu Sans Mono', Menlo, Consolas, monospace" font-size="16px">
+<rect width="100%" height="100%" fill="#101010"/>
+<text x="0" y="15" fill="#d8d8d8" textLength="720" lengthAdjust="spacingAndGlyphs" xml:space="preserve">  Intro paragraph.                                                      </text>
+<text x="0" y="55" fill="#d8d8d8" textLength="720" lengthAdjust="spacingAndGlyphs" xml:space="preserve">  Pure is a modern, terminal-based word processor.                      </text>
+<rect x="0" y="340" width="720" height="20" fill="#2472c8"/>
+<text x="0" y="355" fill="#ffffff" textLength="720" lengthAdjust="spacingAndGlyphs" xml:space="preserve">3:19 Reveal codes enabled                                               </text>
+<rect x="200" y="40" width="10" height="20" fill="#ffffff" fill-opacity="0.4"/>
+</svg>

--- a/src/snapshots/editing_keeps_reveal_codes_visible.snap
+++ b/src/snapshots/editing_keeps_reveal_codes_visible.snap
@@ -1,0 +1,5 @@
+---
+source: src/snapshot_tests.rs
+extension: svg
+snapshot_kind: binary
+---

--- a/src/snapshots/editing_keeps_reveal_codes_visible.snap.svg
+++ b/src/snapshots/editing_keeps_reveal_codes_visible.snap.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="360" viewBox="0 0 720 360" font-family="'DejaVu Sans Mono', Menlo, Consolas, monospace" font-size="16px">
+<rect width="100%" height="100%" fill="#101010"/>
+<text x="0" y="15" fill="#d8d8d8" textLength="200" lengthAdjust="spacingAndGlyphs" xml:space="preserve">  Pure is a modern, </text>
+<rect x="200" y="0" width="80" height="20" fill="#e5e5e5"/>
+<text x="200" y="15" fill="#000000" textLength="80" lengthAdjust="spacingAndGlyphs" xml:space="preserve">[Italic&gt;</text>
+<text x="280" y="15" fill="#d8d8d8" textLength="290" lengthAdjust="spacingAndGlyphs" xml:space="preserve" font-style="italic">terminal-based word processor</text>
+<rect x="570" y="0" width="80" height="20" fill="#e5e5e5"/>
+<text x="570" y="15" fill="#000000" textLength="80" lengthAdjust="spacingAndGlyphs" xml:space="preserve">&lt;Italic]</text>
+<text x="650" y="15" fill="#d8d8d8" textLength="70" lengthAdjust="spacingAndGlyphs" xml:space="preserve">.      </text>
+<rect x="0" y="340" width="720" height="20" fill="#2472c8"/>
+<text x="0" y="355" fill="#ffffff" textLength="720" lengthAdjust="spacingAndGlyphs" xml:space="preserve">1:6 Reveal codes enabled                                                </text>
+<rect x="70" y="0" width="10" height="20" fill="#ffffff" fill-opacity="0.4"/>
+</svg>

--- a/src/snapshots/italic_keeps_cursor_at_selection_end.snap
+++ b/src/snapshots/italic_keeps_cursor_at_selection_end.snap
@@ -1,0 +1,5 @@
+---
+source: src/snapshot_tests.rs
+extension: svg
+snapshot_kind: binary
+---

--- a/src/snapshots/italic_keeps_cursor_at_selection_end.snap.svg
+++ b/src/snapshots/italic_keeps_cursor_at_selection_end.snap.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="360" viewBox="0 0 720 360" font-family="'DejaVu Sans Mono', Menlo, Consolas, monospace" font-size="16px">
+<rect width="100%" height="100%" fill="#101010"/>
+<text x="0" y="15" fill="#d8d8d8" textLength="720" lengthAdjust="spacingAndGlyphs" xml:space="preserve">  Intro paragraph.                                                      </text>
+<text x="0" y="55" fill="#d8d8d8" textLength="200" lengthAdjust="spacingAndGlyphs" xml:space="preserve">  Pure is a modern, </text>
+<text x="200" y="55" fill="#d8d8d8" textLength="290" lengthAdjust="spacingAndGlyphs" xml:space="preserve" font-style="italic">terminal-based word processor</text>
+<text x="490" y="55" fill="#d8d8d8" textLength="230" lengthAdjust="spacingAndGlyphs" xml:space="preserve">.                      </text>
+<rect x="0" y="340" width="50" height="20" fill="#2472c8"/>
+<text x="0" y="355" fill="#ffffff" textLength="50" lengthAdjust="spacingAndGlyphs" xml:space="preserve">3:48 </text>
+<rect x="50" y="340" width="100" height="20" fill="#2472c8"/>
+<text x="50" y="355" fill="#f5f543" textLength="100" lengthAdjust="spacingAndGlyphs" xml:space="preserve">test.ftml*</text>
+<rect x="150" y="340" width="570" height="20" fill="#2472c8"/>
+<text x="150" y="355" fill="#ffffff" textLength="570" lengthAdjust="spacingAndGlyphs" xml:space="preserve"> Text &gt; Italic, 3 lines, 10 words         ^S:Save ^Q:Quit</text>
+<rect x="490" y="40" width="10" height="20" fill="#ffffff" fill-opacity="0.4"/>
+</svg>


### PR DESCRIPTION
- Applying an inline style to a selection no longer makes the cursor jump to the beginning of the selection; it stays at the position it had before.
- With reveal codes shown, pressing Backspace directly behind a start tag like `[Italic>` removes the formatting again instead of merging the paragraph into the previous one, and the cursor stays at the position of the removed tag. The same root cause made Backspace at a style-span boundary merge paragraphs with reveal codes hidden, too.
- Inserting or deleting a character in a line that shows reveal codes later in the line no longer hides those codes (while keeping the formatting) until the next full re-render.