### PR TITLE
Add support for Open/Save As dialogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,12 @@ While pre-1.0, the minor version is bumped for breaking changes.
   extension and starts a new document for nonexistent paths; Save As writes
   in the format of the new extension, so saving a `.md` copy of an `.ftml`
   document converts it. Destructive accepts — opening over unsaved changes,
-  overwriting another file — need a confirming second Enter.
+  overwriting another file — need a confirming second Enter. (#34)
 - New (Ctrl+N) in the File menu starts an untitled document, and Pure can
   now be started without a filename argument to do the same. Untitled
   documents show "Untitled" in the status bar, and saving one opens the
   Save As dialog to ask for a name first. With unsaved changes, New warns
-  in the status line and only a repeated New discards them.
+  in the status line and only a repeated New discards them. (#34)
 - Clipboard support: Ctrl+X/Ctrl+C cut/copy the selection and Ctrl+V pastes,
   all also available in the Edit and context menus. Ctrl+C therefore no
   longer quits Pure; use Ctrl+Q for that. The internal clipboard keeps the selection

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ While pre-1.0, the minor version is bumped for breaking changes.
   in the format of the new extension, so saving a `.md` copy of an `.ftml`
   document converts it. Destructive accepts — opening over unsaved changes,
   overwriting another file — need a confirming second Enter.
+- New (Ctrl+N) in the File menu starts an untitled document, and Pure can
+  now be started without a filename argument to do the same. Untitled
+  documents show "Untitled" in the status bar, and saving one opens the
+  Save As dialog to ask for a name first. With unsaved changes, New warns
+  in the status line and only a repeated New discards them.
 - Clipboard support: Ctrl+X/Ctrl+C cut/copy the selection and Ctrl+V pastes,
   all also available in the Edit and context menus. Ctrl+C therefore no
   longer quits Pure; use Ctrl+Q for that. The internal clipboard keeps the selection

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ While pre-1.0, the minor version is bumped for breaking changes.
 
 ### Added
 
+- Open... (Ctrl+O) and Save As... in the File menu. Both show a modal file
+  dialog: a path input with shell-style Tab completion above a live listing
+  of the directory it points into, navigable with the arrow keys (Enter
+  descends into directories). Opening loads FTML or Markdown based on the
+  extension and starts a new document for nonexistent paths; Save As writes
+  in the format of the new extension, so saving a `.md` copy of an `.ftml`
+  document converts it. Destructive accepts — opening over unsaved changes,
+  overwriting another file — need a confirming second Enter.
 - Clipboard support: Ctrl+X/Ctrl+C cut/copy the selection and Ctrl+V pastes,
   all also available in the Edit and context menus. Ctrl+C therefore no
   longer quits Pure; use Ctrl+Q for that. The internal clipboard keeps the selection

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Pure provides an intuitive editing experience:
 
 Pure is designed for efficiency with comprehensive keyboard shortcuts:
 
+- **Ctrl+O** - Open document (file dialog with tab completion)
 - **Ctrl+S** - Save document
 - **Ctrl+Q** - Quit (with save prompt)
 - **Ctrl+Z / Ctrl+Y** - Undo / redo
@@ -156,7 +157,9 @@ pure webpage.html
 
 **File Operations:**
 
+- Ctrl+O - Open (file dialog with tab completion)
 - Ctrl+S - Save
+- Save As... in the File menu saves under a new name
 - Ctrl+Q - Quit
 
 **Special Features:**

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ pure document.ftml
 
 # Or work with Markdown
 pure notes.md
+
+# Or start with an untitled document and name it on first save
+pure
 ```
 
 ## Features
@@ -72,8 +75,9 @@ Pure provides an intuitive editing experience:
 
 Pure is designed for efficiency with comprehensive keyboard shortcuts:
 
+- **Ctrl+N** - New untitled document
 - **Ctrl+O** - Open document (file dialog with tab completion)
-- **Ctrl+S** - Save document
+- **Ctrl+S** - Save document (asks for a name when untitled)
 - **Ctrl+Q** - Quit (with save prompt)
 - **Ctrl+Z / Ctrl+Y** - Undo / redo
 - **Ctrl+X / Ctrl+C / Ctrl+V** - Cut / copy / paste
@@ -157,8 +161,9 @@ pure webpage.html
 
 **File Operations:**
 
+- Ctrl+N - New untitled document
 - Ctrl+O - Open (file dialog with tab completion)
-- Ctrl+S - Save
+- Ctrl+S - Save (asks for a name when untitled)
 - Save As... in the File menu saves under a new name
 - Ctrl+Q - Quit
 

--- a/USER-GUIDE.md
+++ b/USER-GUIDE.md
@@ -144,11 +144,14 @@ Erases characters to the immediate left of the cursor as you type.
 **Delete**
 Deletes the character at the cursor position.
 
+**Ctrl+O**
+Opens another document. A file dialog lets you type a path — with Tab completion, like in a shell — or pick a file from the listing with the arrow keys.
+
 **Ctrl+Q**
 Exits Pure. You will be prompted to save any unsaved changes.
 
 **Ctrl+S**
-Saves the current document.
+Saves the current document. To save under a different name, use Save As... in the File menu.
 
 **Ctrl+X**, **Ctrl+C**, **Ctrl+V**
 Cut, copy, and paste. Cut and copied text also reaches the system clipboard through your terminal.
@@ -1151,7 +1154,7 @@ Pure uses FTML as its primary format because FTML preserves all formatting infor
 
 The menu bar stays hidden while you write. When activated, it appears at the top of the screen with these menus:
 
-- **File** - Save (Ctrl+S), Quit (Ctrl+Q)
+- **File** - Open... (Ctrl+O), Save (Ctrl+S), Save As..., Quit (Ctrl+Q)
 - **Edit** - Undo (Ctrl+Z), Redo (Ctrl+Y), Cut (Ctrl+X), Copy (Ctrl+C), Paste (Ctrl+V)
 - **Insert** - Line Break (Ctrl+J), Sibling Paragraph (Ctrl+P)
 - **Format** - Formatting Menu (Esc or Ctrl+Space)
@@ -1315,7 +1318,13 @@ Pure starts and loads the specified document.
 
 #### To open a document from within Pure:
 
-The Retrieve feature for opening documents while Pure is running is planned for a future release. Currently, you must specify the filename when starting Pure.
+1. Press **Ctrl+O**, or choose **Open...** from the File menu.
+
+2. Type the path to the document. Press **Tab** to complete it like in a shell, or pick an entry from the listing with the **Up/Down** arrow keys — selecting a directory with **Enter** descends into it.
+
+3. Press **Enter** to open the document, or **Esc** to cancel.
+
+If the current document has unsaved changes, Pure asks you to press Enter a second time before discarding them.
 
 #### Supported File Types:
 
@@ -1500,15 +1509,13 @@ The document is saved to disk.
 
 #### To save with a new name:
 
-Currently, Pure doesn't have a "Save As" feature. To save a document with a new name:
+1. Choose **Save As...** from the File menu (**Alt+F**).
 
-1. Exit Pure (Ctrl+Q).
+2. Edit the suggested path in the file dialog. Press **Tab** to complete a path like in a shell, or pick a directory or file from the listing with the **Up/Down** arrow keys.
 
-2. Copy the file to a new name using your terminal.
+3. Press **Enter** to save, or **Esc** to cancel.
 
-3. Open the new file with Pure.
-
-A dedicated "Save As" feature is planned for future releases.
+If the chosen name already belongs to another file, Pure asks you to press Enter a second time before overwriting it.
 
 #### Filename Extensions:
 
@@ -1581,6 +1588,8 @@ There are no automatic saves or backup copies. Remember to save frequently (Ctrl
 **Ctrl+Y** - Redo last undone change
 
 ### File Operations
+
+**Ctrl+O** - Open document
 
 **Ctrl+S** - Save document
 

--- a/USER-GUIDE.md
+++ b/USER-GUIDE.md
@@ -85,6 +85,14 @@ You can also open Markdown files:
 pure document.md
 ```
 
+**To start with a new, untitled document:**
+
+```
+pure
+```
+
+The status line shows "Untitled" until you save the document; pressing **Ctrl+S** then opens the Save As dialog so you can give it a name.
+
 ### The Clean Screen
 
 When you start Pure, you see the editing screen.
@@ -112,7 +120,7 @@ The **status line** displays information about your document and cursor position
 - The current line number
 - The cursor position on the line
 
-When you save a document, the status line displays the filename.
+The status line displays the document's filename — or "Untitled" before the document has been saved for the first time.
 
 ### Document Structure
 
@@ -144,6 +152,9 @@ Erases characters to the immediate left of the cursor as you type.
 **Delete**
 Deletes the character at the cursor position.
 
+**Ctrl+N**
+Starts a new, untitled document. If the current document has unsaved changes, Pure warns first; select New again to discard them.
+
 **Ctrl+O**
 Opens another document. A file dialog lets you type a path — with Tab completion, like in a shell — or pick a file from the listing with the arrow keys.
 
@@ -151,7 +162,7 @@ Opens another document. A file dialog lets you type a path — with Tab completi
 Exits Pure. You will be prompted to save any unsaved changes.
 
 **Ctrl+S**
-Saves the current document. To save under a different name, use Save As... in the File menu.
+Saves the current document. An untitled document asks for a name through the Save As dialog first. To save under a different name, use Save As... in the File menu.
 
 **Ctrl+X**, **Ctrl+C**, **Ctrl+V**
 Cut, copy, and paste. Cut and copied text also reaches the system clipboard through your terminal.
@@ -323,7 +334,7 @@ Now that you've created a document, save it:
 
 1. Press **Ctrl+S**.
 
-2. If this is a new document, you'll be prompted for a filename.
+2. Since this is a new document, the Save As dialog opens to ask for a filename.
 
 3. Type: **study-abroad.ftml** and press **Enter**.
 
@@ -1154,7 +1165,7 @@ Pure uses FTML as its primary format because FTML preserves all formatting infor
 
 The menu bar stays hidden while you write. When activated, it appears at the top of the screen with these menus:
 
-- **File** - Open... (Ctrl+O), Save (Ctrl+S), Save As..., Quit (Ctrl+Q)
+- **File** - New (Ctrl+N), Open... (Ctrl+O), Save (Ctrl+S), Save As..., Quit (Ctrl+Q)
 - **Edit** - Undo (Ctrl+Z), Redo (Ctrl+Y), Cut (Ctrl+X), Copy (Ctrl+C), Paste (Ctrl+V)
 - **Insert** - Line Break (Ctrl+J), Sibling Paragraph (Ctrl+P)
 - **Format** - Formatting Menu (Esc or Ctrl+Space)
@@ -1245,6 +1256,26 @@ Mouse support includes:
 - **Scroll** - Navigate through document
 
 Selection boundaries respect formatting structure. When you select text, you can see exactly what will be affected by formatting changes, especially when used with Reveal Codes mode (F9).
+
+---
+
+### New Document
+
+**Purpose:** Start a new, untitled document.
+
+**Keyboard Shortcut:** Ctrl+N
+
+#### To start a new document:
+
+1. Press **Ctrl+N**, or choose **New** from the File menu.
+
+2. If the current document has unsaved changes, Pure warns you in the status line. Select New again to discard them, or save first.
+
+The new document is untitled — the status line shows "Untitled" — and is not connected to any file yet. Pressing **Ctrl+S** opens the Save As dialog to ask for a name.
+
+#### Additional Information:
+
+Starting Pure without a filename argument (`pure`) begins with an untitled document in the same way.
 
 ---
 
@@ -1501,9 +1532,9 @@ The visible codes in Pure are representations of the FTML structure. They show w
 
 1. Press **Ctrl+S**.
 
-2. If this is a new document that hasn't been saved before, Pure prompts you for a filename.
+2. If the document is untitled (started without a filename or via File > New), the Save As dialog opens.
 
-3. Type a filename and press **Enter**.
+3. Type a filename — **Tab** completes the path like in a shell — and press **Enter**.
 
 The document is saved to disk.
 
@@ -1588,6 +1619,8 @@ There are no automatic saves or backup copies. Remember to save frequently (Ctrl
 **Ctrl+Y** - Redo last undone change
 
 ### File Operations
+
+**Ctrl+N** - New untitled document
 
 **Ctrl+O** - Open document
 

--- a/examples/demo/player.rs
+++ b/examples/demo/player.rs
@@ -32,7 +32,7 @@ impl Backend {
     pub fn start(columns: u16, rows: u16) -> Self {
         let app = App::new(
             Document::new(),
-            PathBuf::from("demo.md"),
+            Some(PathBuf::from("demo.md")),
             DocumentFormat::Markdown,
             None,
         );

--- a/src/app.rs
+++ b/src/app.rs
@@ -32,6 +32,7 @@ use tdoc::{Document, InlineStyle, ParagraphType, markdown, parse, writer::Writer
 
 use crate::editor::{CursorPointer, DocumentEditor};
 use crate::editor_display::{CursorDisplay, EditorDisplay};
+use crate::file_dialog::{FileDialogKind, FileDialogResult, FileDialogState};
 use crate::menu_bar::{
     AppAction, MENU_BAR, MenuBarEntry, MenuBarState, menu_title_offset, menu_with_accel,
 };
@@ -536,7 +537,9 @@ enum DragState {
 
 pub struct App {
     display: EditorDisplay,
-    file_path: PathBuf,
+    /// Path of the current document; `None` while it is untitled (started
+    /// without an argument or via File > New).
+    file_path: Option<PathBuf>,
     document_format: DocumentFormat,
     scroll_top: usize,
     should_quit: bool,
@@ -550,6 +553,7 @@ pub struct App {
     clipboard: Option<ClipboardContents>,
     context_menu: Option<ContextMenuState>,
     menu_bar: Option<MenuBarState>,
+    file_dialog: Option<FileDialogState>,
     last_click_instant: Option<Instant>,
     last_click_position: Option<(u16, u16)>,
     last_click_button: Option<MouseButton>,
@@ -570,7 +574,7 @@ pub struct App {
 impl App {
     pub fn new(
         document: Document,
-        path: PathBuf,
+        path: Option<PathBuf>,
         format: DocumentFormat,
         initial_status: Option<String>,
     ) -> Self {
@@ -590,6 +594,8 @@ impl App {
             clipboard: None,
             context_menu: None,
             menu_bar: None,
+            file_dialog: None,
+            confirm_new: false,
             last_click_instant: None,
             last_click_position: None,
             last_click_button: None,
@@ -996,6 +1002,131 @@ impl App {
         if self.menu_bar.is_some() {
             self.render_menu_bar(frame, area);
         }
+
+        if self.file_dialog.is_some() {
+            self.render_file_dialog(frame, area);
+        }
+    }
+
+    fn render_file_dialog(&self, frame: &mut Frame, area: Rect) {
+        let Some(dialog) = &self.file_dialog else {
+            return;
+        };
+        if area.width < 20 || area.height < 8 {
+            return;
+        }
+
+        let theme = self.display.theme();
+        let popup_style = theme.menu_style();
+
+        // Input line, separator, up to eight listing rows, and a footer,
+        // plus the border.
+        let width = 60.min(area.width.saturating_sub(4));
+        let list_rows = dialog.candidates().len().clamp(1, 8) as u16;
+        let height = (list_rows + 5).min(area.height.saturating_sub(2));
+        let popup_area = Rect::new(
+            area.x + (area.width.saturating_sub(width)) / 2,
+            area.y + (area.height.saturating_sub(height)) / 2,
+            width,
+            height,
+        );
+
+        frame.render_widget(Clear, popup_area);
+
+        let title = match dialog.kind() {
+            FileDialogKind::Open => "Open File",
+            FileDialogKind::SaveAs => "Save As",
+        };
+        let block = Block::default()
+            .title(title)
+            .borders(Borders::ALL)
+            .style(popup_style)
+            .border_style(Style::default().fg(Color::Gray));
+        let inner = block.inner(popup_area);
+        frame.render_widget(block, popup_area);
+        if inner.width < 3 || inner.height < 4 {
+            return;
+        }
+
+        // Path input, horizontally scrolled so the cursor stays visible.
+        let input_area = Rect::new(inner.x + 1, inner.y, inner.width - 2, 1);
+        let visible = input_area.width as usize;
+        let skip = (dialog.cursor() + 1).saturating_sub(visible);
+        let shown: String = dialog.input().chars().skip(skip).take(visible).collect();
+        frame.render_widget(Paragraph::new(shown).style(popup_style), input_area);
+        frame.set_cursor_position(Position::new(
+            input_area.x + (dialog.cursor() - skip) as u16,
+            input_area.y,
+        ));
+
+        let separator = "─".repeat(inner.width as usize);
+        frame.render_widget(
+            Paragraph::new(Line::from(Span::styled(
+                separator,
+                Style::default().fg(Color::DarkGray),
+            )))
+            .style(popup_style),
+            Rect::new(inner.x, inner.y + 1, inner.width, 1),
+        );
+
+        let list_area = Rect::new(
+            inner.x,
+            inner.y + 2,
+            inner.width,
+            inner.height.saturating_sub(3),
+        );
+        if dialog.candidates().is_empty() {
+            frame.render_widget(
+                Paragraph::new(" (no matching files)")
+                    .style(popup_style.patch(theme.menu_disabled_style())),
+                list_area,
+            );
+        } else {
+            let items: Vec<ListItem> = dialog
+                .candidates()
+                .iter()
+                .map(|candidate| {
+                    let (name, style) = if candidate.is_dir {
+                        (
+                            format!(" {}/", candidate.name),
+                            Style::default().add_modifier(Modifier::BOLD),
+                        )
+                    } else {
+                        (format!(" {}", candidate.name), Style::default())
+                    };
+                    ListItem::new(Line::from(Span::styled(name, style)))
+                })
+                .collect();
+            let mut list_state = ListState::default();
+            list_state.select(dialog.selected());
+            let list = List::new(items)
+                .highlight_style(theme.menu_selected_style())
+                .style(popup_style);
+            frame.render_stateful_widget(list, list_area, &mut list_state);
+        }
+
+        // Footer: pending confirmation warning, otherwise key hints.
+        let footer_area = Rect::new(inner.x + 1, inner.y + inner.height - 1, inner.width - 2, 1);
+        let footer = if dialog.pending_confirm().is_some() {
+            let warning = match dialog.kind() {
+                FileDialogKind::Open => "Unsaved changes — press Enter again to discard them",
+                FileDialogKind::SaveAs => "File exists — press Enter again to overwrite",
+            };
+            Span::styled(warning, Style::default().fg(Color::LightYellow))
+        } else {
+            let action = match dialog.kind() {
+                FileDialogKind::Open => "open",
+                FileDialogKind::SaveAs => "save",
+            };
+            Span::styled(
+                format!("Tab: complete  Enter: {action}  Esc: cancel"),
+                theme.menu_disabled_style(),
+            )
+        };
+        frame.render_widget(
+            Paragraph::new(Line::from(footer)).style(popup_style),
+            footer_area,
+        );
     }
 
     fn render_menu_bar(&self, frame: &mut Frame, area: Rect) {
@@ -1551,7 +1682,9 @@ impl App {
     fn execute_app_action(&mut self, action: AppAction) -> Result<()> {
         let previous_cursor = self.display.cursor_pointer();
         match action {
+            AppAction::Open => self.open_file_dialog(FileDialogKind::Open),
             AppAction::Save => self.save()?,
+            AppAction::SaveAs => self.open_file_dialog(FileDialogKind::SaveAs),
             AppAction::Quit => self.should_quit = true,
             AppAction::Undo => self.undo(),
             AppAction::Redo => self.redo(),
@@ -2049,6 +2182,10 @@ impl App {
                 kind: KeyEventKind::Press,
                 ..
             }) => {
+                if self.handle_file_dialog_key(code, modifiers) {
+                    return Ok(());
+                }
+
                 if self.handle_menu_bar_key(code, modifiers)? {
                     return Ok(());
                 }
@@ -2078,6 +2215,9 @@ impl App {
                     }
                     (KeyCode::Char('s'), m) if m.contains(KeyModifiers::CONTROL) => {
                         self.save()?;
+                    }
+                    (KeyCode::Char('o'), m) if m.contains(KeyModifiers::CONTROL) => {
+                        self.open_file_dialog(FileDialogKind::Open);
                     }
                     (KeyCode::F(9), _) => {
                         self.toggle_reveal_codes();
@@ -2289,10 +2429,17 @@ impl App {
                 }
             }
             Event::Mouse(mouse_event) => {
+                if self.file_dialog.is_some() {
+                    return Ok(());
+                }
                 self.handle_mouse_event(mouse_event);
             }
             Event::Paste(text) if self.context_menu.is_none() && self.menu_bar.is_none() => {
-                self.paste_text(&text);
+                if let Some(dialog) = self.file_dialog.as_mut() {
+                    dialog.insert_str(&text);
+                } else {
+                    self.paste_text(&text);
+                }
             }
             _ => {}
         }
@@ -2325,6 +2472,160 @@ impl App {
         self.dirty = false;
         self.status_message = Some(("Saved".to_string(), Instant::now()));
         Ok(())
+    }
+
+    fn open_file_dialog(&mut self, kind: FileDialogKind) {
+        let initial_input = match kind {
+            // Start in the current file's directory so its siblings are
+            // listed right away.
+            FileDialogKind::Open => match self.file_path.parent() {
+                Some(parent) if !parent.as_os_str().is_empty() => {
+                    let parent = parent.display().to_string();
+                    if parent.ends_with('/') {
+                        parent
+                    } else {
+                        format!("{parent}/")
+                    }
+                }
+                _ => String::new(),
+            },
+            // Suggest the current path so saving under a sibling name only
+            // needs the file name edited.
+            FileDialogKind::SaveAs => self.file_path.display().to_string(),
+        };
+        self.file_dialog = Some(FileDialogState::new(kind, initial_input));
+    }
+
+    /// Handle a key press while the file dialog is open. The dialog is
+    /// modal: every key is consumed.
+    fn handle_file_dialog_key(&mut self, code: KeyCode, modifiers: KeyModifiers) -> bool {
+        if self.file_dialog.is_none() {
+            return false;
+        }
+
+        match (code, modifiers) {
+            (KeyCode::Esc, _) => {
+                self.file_dialog = None;
+            }
+            (KeyCode::Enter, _) => {
+                let result = self
+                    .file_dialog
+                    .as_mut()
+                    .expect("file dialog checked above")
+                    .enter();
+                if let FileDialogResult::Accept(path) = result {
+                    self.accept_file_dialog(path);
+                }
+            }
+            _ => {
+                let Some(dialog) = self.file_dialog.as_mut() else {
+                    return true;
+                };
+                match (code, modifiers) {
+                    (KeyCode::Tab, _) => dialog.complete(),
+                    (KeyCode::Up, _) => dialog.move_selection(-1),
+                    (KeyCode::Down, _) => dialog.move_selection(1),
+                    (KeyCode::Left, _) => dialog.move_cursor_left(),
+                    (KeyCode::Right, _) => dialog.move_cursor_right(),
+                    (KeyCode::Home, _) => dialog.move_cursor_start(),
+                    (KeyCode::End, _) => dialog.move_cursor_end(),
+                    (KeyCode::Char('a'), m) if m.contains(KeyModifiers::CONTROL) => {
+                        dialog.move_cursor_start()
+                    }
+                    (KeyCode::Char('e'), m) if m.contains(KeyModifiers::CONTROL) => {
+                        dialog.move_cursor_end()
+                    }
+                    (KeyCode::Char('w'), m) if m.contains(KeyModifiers::CONTROL) => {
+                        dialog.delete_word_backward()
+                    }
+                    (KeyCode::Backspace, m)
+                        if m.contains(KeyModifiers::CONTROL) || m.contains(KeyModifiers::ALT) =>
+                    {
+                        dialog.delete_word_backward()
+                    }
+                    (KeyCode::Backspace, _) => dialog.backspace(),
+                    (KeyCode::Delete, _) => dialog.delete(),
+                    (KeyCode::Char(ch), m)
+                        if !m.contains(KeyModifiers::CONTROL) && !m.contains(KeyModifiers::ALT) =>
+                    {
+                        dialog.insert_char(ch)
+                    }
+                    _ => {}
+                }
+            }
+        }
+        true
+    }
+
+    /// Act on a path accepted in the file dialog. Destructive accepts —
+    /// opening over unsaved changes, overwriting another file — require a
+    /// second Enter on the unchanged path.
+    fn accept_file_dialog(&mut self, path: PathBuf) {
+        let Some(dialog) = self.file_dialog.as_mut() else {
+            return;
+        };
+        let kind = dialog.kind();
+        let needs_confirmation = match kind {
+            FileDialogKind::Open => self.dirty,
+            FileDialogKind::SaveAs => path != self.file_path && path.exists(),
+        };
+        if needs_confirmation && dialog.pending_confirm() != Some(path.as_path()) {
+            dialog.set_pending_confirm(path);
+            return;
+        }
+
+        self.file_dialog = None;
+        match kind {
+            FileDialogKind::Open => self.open_file(path),
+            FileDialogKind::SaveAs => self.save_as(path),
+        }
+    }
+
+    /// Replace the current document with the one loaded from `path`. A
+    /// nonexistent path starts a new document there, mirroring the CLI.
+    fn open_file(&mut self, path: PathBuf) {
+        match load_document(&path) {
+            Ok((document, format, message)) => {
+                let reveal_codes = self.display.reveal_codes();
+                let mut editor = DocumentEditor::new(document);
+                editor.ensure_cursor_selectable();
+                self.display = EditorDisplay::new(editor);
+                self.display.set_reveal_codes(reveal_codes);
+                self.file_path = path;
+                self.document_format = format;
+                self.dirty = false;
+                self.scroll_top = 0;
+                self.selection_anchor = None;
+                self.needs_position_rebuild = true;
+                let message =
+                    message.unwrap_or_else(|| format!("Opened {}", self.file_path.display()));
+                self.status_message = Some((message, Instant::now()));
+            }
+            Err(err) => {
+                self.status_message = Some((format!("{err:#}"), Instant::now()));
+            }
+        }
+    }
+
+    /// Save under a new path; the format follows the new extension. On
+    /// failure the previous path and format are restored.
+    fn save_as(&mut self, path: PathBuf) {
+        let previous_path = std::mem::replace(&mut self.file_path, path);
+        let previous_format = self.document_format;
+        self.document_format = DocumentFormat::from_path(&self.file_path);
+        match self.save() {
+            Ok(()) => {
+                self.status_message = Some((
+                    format!("Saved {}", self.file_path.display()),
+                    Instant::now(),
+                ));
+            }
+            Err(err) => {
+                self.file_path = previous_path;
+                self.document_format = previous_format;
+                self.status_message = Some((format!("{err:#}"), Instant::now()));
+            }
+        }
     }
 
     fn mark_dirty(&mut self) {

--- a/src/app.rs
+++ b/src/app.rs
@@ -554,6 +554,9 @@ pub struct App {
     context_menu: Option<ContextMenuState>,
     menu_bar: Option<MenuBarState>,
     file_dialog: Option<FileDialogState>,
+    /// Whether the next New command may discard unsaved changes: the first
+    /// one only warns. Cleared again by any edit.
+    confirm_new: bool,
     last_click_instant: Option<Instant>,
     last_click_position: Option<(u16, u16)>,
     last_click_button: Option<MouseButton>,
@@ -1682,6 +1685,7 @@ impl App {
     fn execute_app_action(&mut self, action: AppAction) -> Result<()> {
         let previous_cursor = self.display.cursor_pointer();
         match action {
+            AppAction::New => self.new_document(),
             AppAction::Open => self.open_file_dialog(FileDialogKind::Open),
             AppAction::Save => self.save()?,
             AppAction::SaveAs => self.open_file_dialog(FileDialogKind::SaveAs),
@@ -1727,7 +1731,11 @@ impl App {
         }
 
         let position = self.cursor_position_text();
-        let filename = self.file_path.display().to_string();
+        let filename = self
+            .file_path
+            .as_ref()
+            .map(|path| path.display().to_string())
+            .unwrap_or_else(|| "Untitled".to_string());
         let marker = if self.dirty { "*" } else { "" };
         let breadcrumbs = self.breadcrumbs_text();
         let word_count = self.count_words();
@@ -2219,6 +2227,9 @@ impl App {
                     (KeyCode::Char('o'), m) if m.contains(KeyModifiers::CONTROL) => {
                         self.open_file_dialog(FileDialogKind::Open);
                     }
+                    (KeyCode::Char('n'), m) if m.contains(KeyModifiers::CONTROL) => {
+                        self.new_document();
+                    }
                     (KeyCode::F(9), _) => {
                         self.toggle_reveal_codes();
                     }
@@ -2451,21 +2462,28 @@ impl App {
     }
 
     fn save(&mut self) -> Result<()> {
+        // An untitled document needs a name first; saving continues from
+        // the Save As dialog.
+        let Some(path) = &self.file_path else {
+            self.open_file_dialog(FileDialogKind::SaveAs);
+            return Ok(());
+        };
+
         match self.document_format {
             DocumentFormat::Ftml => {
                 let writer = Writer::new();
                 let contents = writer
                     .write_to_string(self.display.document())
                     .context("failed to render FTML")?;
-                fs::write(&self.file_path, contents)
-                    .with_context(|| format!("failed to write {}", self.file_path.display()))?;
+                fs::write(path, contents)
+                    .with_context(|| format!("failed to write {}", path.display()))?;
             }
             DocumentFormat::Markdown => {
                 let mut contents = Vec::new();
                 markdown::write(&mut contents, self.display.document())
                     .context("failed to render Markdown")?;
-                fs::write(&self.file_path, contents)
-                    .with_context(|| format!("failed to write {}", self.file_path.display()))?;
+                fs::write(path, contents)
+                    .with_context(|| format!("failed to write {}", path.display()))?;
             }
         }
 
@@ -2478,7 +2496,7 @@ impl App {
         let initial_input = match kind {
             // Start in the current file's directory so its siblings are
             // listed right away.
-            FileDialogKind::Open => match self.file_path.parent() {
+            FileDialogKind::Open => match self.file_path.as_ref().and_then(|path| path.parent()) {
                 Some(parent) if !parent.as_os_str().is_empty() => {
                     let parent = parent.display().to_string();
                     if parent.ends_with('/') {
@@ -2491,7 +2509,11 @@ impl App {
             },
             // Suggest the current path so saving under a sibling name only
             // needs the file name edited.
-            FileDialogKind::SaveAs => self.file_path.display().to_string(),
+            FileDialogKind::SaveAs => self
+                .file_path
+                .as_ref()
+                .map(|path| path.display().to_string())
+                .unwrap_or_default(),
         };
         self.file_dialog = Some(FileDialogState::new(kind, initial_input));
     }
@@ -2567,7 +2589,9 @@ impl App {
         let kind = dialog.kind();
         let needs_confirmation = match kind {
             FileDialogKind::Open => self.dirty,
-            FileDialogKind::SaveAs => path != self.file_path && path.exists(),
+            FileDialogKind::SaveAs => {
+                self.file_path.as_deref() != Some(path.as_path()) && path.exists()
+            }
         };
         if needs_confirmation && dialog.pending_confirm() != Some(path.as_path()) {
             dialog.set_pending_confirm(path);
@@ -2581,24 +2605,51 @@ impl App {
         }
     }
 
+    /// Swap in `document` as the current document and reset all
+    /// per-document state (undo history, selection, scroll, dirty flag).
+    /// Reveal codes mode survives the swap.
+    fn replace_document(
+        &mut self,
+        document: Document,
+        path: Option<PathBuf>,
+        format: DocumentFormat,
+    ) {
+        let reveal_codes = self.display.reveal_codes();
+        let mut editor = DocumentEditor::new(document);
+        editor.ensure_cursor_selectable();
+        self.display = EditorDisplay::new(editor);
+        self.display.set_reveal_codes(reveal_codes);
+        self.file_path = path;
+        self.document_format = format;
+        self.dirty = false;
+        self.confirm_new = false;
+        self.scroll_top = 0;
+        self.selection_anchor = None;
+        self.needs_position_rebuild = true;
+    }
+
+    /// Start an untitled document. With unsaved changes the first call only
+    /// warns; repeating the command discards them.
+    fn new_document(&mut self) {
+        if self.dirty && !self.confirm_new {
+            self.confirm_new = true;
+            self.status_message = Some((
+                "Unsaved changes — select New again to discard them".to_string(),
+                Instant::now(),
+            ));
+            return;
+        }
+        self.replace_document(Document::new(), None, DocumentFormat::Ftml);
+        self.status_message = Some(("New document".to_string(), Instant::now()));
+    }
+
     /// Replace the current document with the one loaded from `path`. A
     /// nonexistent path starts a new document there, mirroring the CLI.
     fn open_file(&mut self, path: PathBuf) {
         match load_document(&path) {
             Ok((document, format, message)) => {
-                let reveal_codes = self.display.reveal_codes();
-                let mut editor = DocumentEditor::new(document);
-                editor.ensure_cursor_selectable();
-                self.display = EditorDisplay::new(editor);
-                self.display.set_reveal_codes(reveal_codes);
-                self.file_path = path;
-                self.document_format = format;
-                self.dirty = false;
-                self.scroll_top = 0;
-                self.selection_anchor = None;
-                self.needs_position_rebuild = true;
-                let message =
-                    message.unwrap_or_else(|| format!("Opened {}", self.file_path.display()));
+                let message = message.unwrap_or_else(|| format!("Opened {}", path.display()));
+                self.replace_document(document, Some(path), format);
                 self.status_message = Some((message, Instant::now()));
             }
             Err(err) => {
@@ -2610,15 +2661,16 @@ impl App {
     /// Save under a new path; the format follows the new extension. On
     /// failure the previous path and format are restored.
     fn save_as(&mut self, path: PathBuf) {
-        let previous_path = std::mem::replace(&mut self.file_path, path);
+        let previous_path = self.file_path.take();
         let previous_format = self.document_format;
-        self.document_format = DocumentFormat::from_path(&self.file_path);
+        self.document_format = DocumentFormat::from_path(&path);
+        self.file_path = Some(path);
         match self.save() {
             Ok(()) => {
-                self.status_message = Some((
-                    format!("Saved {}", self.file_path.display()),
-                    Instant::now(),
-                ));
+                if let Some(path) = &self.file_path {
+                    self.status_message =
+                        Some((format!("Saved {}", path.display()), Instant::now()));
+                }
             }
             Err(err) => {
                 self.file_path = previous_path;
@@ -2630,6 +2682,7 @@ impl App {
 
     fn mark_dirty(&mut self) {
         self.dirty = true;
+        self.confirm_new = false;
         // EditorDisplay now handles layout updates automatically in its wrapper methods
         // (insert_char, delete, backspace, etc.) which includes position tracking via
         // incremental updates. No need to force a full re-render here.

--- a/src/bin/pure.rs
+++ b/src/bin/pure.rs
@@ -16,21 +16,25 @@ use crossterm::{
 };
 use ratatui::{Terminal, backend::CrosstermBackend};
 
-use pure_tui::app::{App, load_document};
+use pure_tui::app::{App, DocumentFormat, load_document};
+use tdoc::Document;
 
 fn main() -> Result<()> {
     run()
 }
 
 fn run() -> Result<()> {
-    let mut args = env::args().skip(1);
-    let Some(path_arg) = args.next() else {
-        eprintln!("Usage: cargo run -- <file.ftml>");
-        return Ok(());
+    // Without an argument, start with an untitled document; saving it asks
+    // for a name through the Save As dialog.
+    let path = env::args().nth(1).map(PathBuf::from);
+    let (document, format, initial_status) = match &path {
+        Some(path) => load_document(path)?,
+        None => (
+            Document::new(),
+            DocumentFormat::Ftml,
+            Some("New document".to_string()),
+        ),
     };
-    let path = PathBuf::from(path_arg);
-
-    let (document, format, initial_status) = load_document(&path)?;
     let mut app = App::new(document, path, format, initial_status);
 
     enable_raw_mode().context("failed to enable raw mode")?;

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1,0 +1,438 @@
+//! Modal file dialog with shell-style tab completion, used by the File
+//! menu's Open... and Save As... commands.
+//!
+//! The dialog is a single-line path input above a live listing of the
+//! directory the input points into, filtered by the typed file name prefix.
+//! Tab completes like a shell (longest common prefix, unique directories
+//! gain a trailing slash), Up/Down move through the listing, and Enter
+//! either descends into the selected directory or accepts a file. The
+//! surrounding [`crate::app::App`] decides what accepting a path means and
+//! uses [`FileDialogState::pending_confirm`] to require a second Enter for
+//! destructive accepts (overwriting a file, discarding unsaved changes).
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FileDialogKind {
+    Open,
+    SaveAs,
+}
+
+pub struct Candidate {
+    /// File or directory name within the input's directory (no slash).
+    pub name: String,
+    pub is_dir: bool,
+}
+
+/// What pressing Enter did: the dialog either stays open (descended into a
+/// directory, nothing to accept) or yields the chosen path.
+pub enum FileDialogResult {
+    Pending,
+    Accept(PathBuf),
+}
+
+pub struct FileDialogState {
+    kind: FileDialogKind,
+    input: String,
+    /// Cursor position in the input, as a char index.
+    cursor: usize,
+    candidates: Vec<Candidate>,
+    /// Highlighted candidate; `None` keeps focus on the input line.
+    selected: Option<usize>,
+    /// Path whose accept needs confirming with a second Enter. Set by the
+    /// app, cleared by any edit or selection change.
+    pending_confirm: Option<PathBuf>,
+}
+
+impl FileDialogState {
+    pub fn new(kind: FileDialogKind, initial_input: String) -> Self {
+        let mut state = Self {
+            kind,
+            cursor: initial_input.chars().count(),
+            input: initial_input,
+            candidates: Vec::new(),
+            selected: None,
+            pending_confirm: None,
+        };
+        state.refresh();
+        state
+    }
+
+    pub fn kind(&self) -> FileDialogKind {
+        self.kind
+    }
+
+    pub fn input(&self) -> &str {
+        &self.input
+    }
+
+    /// Cursor position as a char index into [`FileDialogState::input`].
+    pub fn cursor(&self) -> usize {
+        self.cursor
+    }
+
+    pub fn candidates(&self) -> &[Candidate] {
+        &self.candidates
+    }
+
+    pub fn selected(&self) -> Option<usize> {
+        self.selected
+    }
+
+    pub fn pending_confirm(&self) -> Option<&Path> {
+        self.pending_confirm.as_deref()
+    }
+
+    pub fn set_pending_confirm(&mut self, path: PathBuf) {
+        self.pending_confirm = Some(path);
+    }
+
+    fn char_len(&self) -> usize {
+        self.input.chars().count()
+    }
+
+    fn byte_index(&self, char_index: usize) -> usize {
+        self.input
+            .char_indices()
+            .nth(char_index)
+            .map(|(index, _)| index)
+            .unwrap_or(self.input.len())
+    }
+
+    /// Split the input at the last slash into the directory part (with the
+    /// slash) and the file name prefix being typed.
+    fn split_input(&self) -> (String, String) {
+        match self.input.rfind('/') {
+            Some(pos) => (
+                self.input[..=pos].to_string(),
+                self.input[pos + 1..].to_string(),
+            ),
+            None => (String::new(), self.input.clone()),
+        }
+    }
+
+    /// Re-list the directory the input points into, keeping only entries
+    /// matching the typed prefix. Hidden entries stay hidden until the
+    /// prefix itself starts with a dot.
+    fn refresh(&mut self) {
+        self.candidates.clear();
+        let (dir, prefix) = self.split_input();
+        let dir_path = if dir.is_empty() {
+            PathBuf::from(".")
+        } else {
+            expand_tilde(&dir)
+        };
+        let Ok(entries) = fs::read_dir(&dir_path) else {
+            return;
+        };
+        let show_hidden = prefix.starts_with('.');
+        for entry in entries.flatten() {
+            let name = entry.file_name().to_string_lossy().into_owned();
+            if !show_hidden && name.starts_with('.') {
+                continue;
+            }
+            if !name.starts_with(&prefix) {
+                continue;
+            }
+            let is_dir = entry.path().is_dir();
+            self.candidates.push(Candidate { name, is_dir });
+        }
+        self.candidates.sort_by(|a, b| {
+            b.is_dir
+                .cmp(&a.is_dir)
+                .then_with(|| a.name.to_lowercase().cmp(&b.name.to_lowercase()))
+                .then_with(|| a.name.cmp(&b.name))
+        });
+    }
+
+    fn edited(&mut self) {
+        self.selected = None;
+        self.pending_confirm = None;
+        self.refresh();
+    }
+
+    fn set_input(&mut self, input: String) {
+        self.input = input;
+        self.cursor = self.char_len();
+        self.edited();
+    }
+
+    pub fn insert_char(&mut self, ch: char) {
+        if ch.is_control() {
+            return;
+        }
+        let at = self.byte_index(self.cursor);
+        self.input.insert(at, ch);
+        self.cursor += 1;
+        self.edited();
+    }
+
+    /// Insert pasted text, dropping control characters (newlines included).
+    pub fn insert_str(&mut self, text: &str) {
+        let filtered: String = text.chars().filter(|ch| !ch.is_control()).collect();
+        if filtered.is_empty() {
+            return;
+        }
+        let at = self.byte_index(self.cursor);
+        self.input.insert_str(at, &filtered);
+        self.cursor += filtered.chars().count();
+        self.edited();
+    }
+
+    pub fn backspace(&mut self) {
+        if self.cursor == 0 {
+            return;
+        }
+        let start = self.byte_index(self.cursor - 1);
+        let end = self.byte_index(self.cursor);
+        self.input.replace_range(start..end, "");
+        self.cursor -= 1;
+        self.edited();
+    }
+
+    pub fn delete(&mut self) {
+        if self.cursor >= self.char_len() {
+            return;
+        }
+        let start = self.byte_index(self.cursor);
+        let end = self.byte_index(self.cursor + 1);
+        self.input.replace_range(start..end, "");
+        self.edited();
+    }
+
+    /// Delete back to the start of the current path component (or the whole
+    /// previous component when the cursor sits right behind its slash).
+    pub fn delete_word_backward(&mut self) {
+        if self.cursor == 0 {
+            return;
+        }
+        let chars: Vec<char> = self.input.chars().collect();
+        let mut target = self.cursor;
+        while target > 0 && chars[target - 1] == '/' {
+            target -= 1;
+        }
+        while target > 0 && chars[target - 1] != '/' {
+            target -= 1;
+        }
+        let start = self.byte_index(target);
+        let end = self.byte_index(self.cursor);
+        self.input.replace_range(start..end, "");
+        self.cursor = target;
+        self.edited();
+    }
+
+    pub fn move_cursor_left(&mut self) {
+        self.cursor = self.cursor.saturating_sub(1);
+    }
+
+    pub fn move_cursor_right(&mut self) {
+        self.cursor = (self.cursor + 1).min(self.char_len());
+    }
+
+    pub fn move_cursor_start(&mut self) {
+        self.cursor = 0;
+    }
+
+    pub fn move_cursor_end(&mut self) {
+        self.cursor = self.char_len();
+    }
+
+    /// Move the listing highlight. The cycle includes "no selection": moving
+    /// past either end puts focus back on the input line, so Enter accepts
+    /// the typed path again.
+    pub fn move_selection(&mut self, delta: i32) {
+        if self.candidates.is_empty() {
+            return;
+        }
+        self.pending_confirm = None;
+        let len = self.candidates.len() as i32;
+        let next = match self.selected {
+            None if delta >= 0 => Some(0),
+            None => Some(len - 1),
+            Some(current) => {
+                let next = current as i32 + delta.signum();
+                (0..len).contains(&next).then_some(next)
+            }
+        };
+        self.selected = next.map(|index| index as usize);
+    }
+
+    /// Shell-style completion: a unique match completes fully (directories
+    /// gain a trailing slash), multiple matches complete to their longest
+    /// common prefix.
+    pub fn complete(&mut self) {
+        if self.candidates.is_empty() {
+            return;
+        }
+        let (dir, prefix) = self.split_input();
+        if let [candidate] = &self.candidates[..] {
+            let mut input = format!("{dir}{}", candidate.name);
+            if candidate.is_dir {
+                input.push('/');
+            }
+            self.set_input(input);
+            return;
+        }
+        let mut lcp = self.candidates[0].name.clone();
+        for candidate in &self.candidates[1..] {
+            lcp = common_prefix(&lcp, &candidate.name);
+            if lcp.is_empty() {
+                break;
+            }
+        }
+        if lcp.chars().count() > prefix.chars().count() {
+            self.set_input(format!("{dir}{lcp}"));
+        }
+    }
+
+    /// Apply Enter: descend into the selected (or typed) directory, or
+    /// resolve the chosen file path for the app to act on.
+    pub fn enter(&mut self) -> FileDialogResult {
+        if let Some(index) = self.selected {
+            let (dir, _) = self.split_input();
+            let candidate = &self.candidates[index];
+            let mut input = format!("{dir}{}", candidate.name);
+            if candidate.is_dir {
+                input.push('/');
+                self.set_input(input);
+                return FileDialogResult::Pending;
+            }
+            self.set_input(input);
+            return FileDialogResult::Accept(self.resolved_path());
+        }
+
+        if self.input.is_empty() {
+            return FileDialogResult::Pending;
+        }
+        let path = self.resolved_path();
+        if path.is_dir() {
+            if !self.input.ends_with('/') {
+                let input = format!("{}/", self.input);
+                self.set_input(input);
+            }
+            return FileDialogResult::Pending;
+        }
+        FileDialogResult::Accept(path)
+    }
+
+    /// The typed path with a leading `~` expanded.
+    pub fn resolved_path(&self) -> PathBuf {
+        expand_tilde(&self.input)
+    }
+}
+
+fn expand_tilde(path: &str) -> PathBuf {
+    if path == "~"
+        && let Some(home) = std::env::var_os("HOME")
+    {
+        return PathBuf::from(home);
+    }
+    if let Some(rest) = path.strip_prefix("~/")
+        && let Some(home) = std::env::var_os("HOME")
+    {
+        return PathBuf::from(home).join(rest);
+    }
+    PathBuf::from(path)
+}
+
+fn common_prefix(a: &str, b: &str) -> String {
+    a.chars()
+        .zip(b.chars())
+        .take_while(|(x, y)| x == y)
+        .map(|(x, _)| x)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dialog_with_input(input: &str) -> FileDialogState {
+        FileDialogState::new(FileDialogKind::Open, input.to_string())
+    }
+
+    #[test]
+    fn lists_directory_filtered_by_prefix() {
+        let dialog = dialog_with_input("tests/fixtures/");
+        let names: Vec<&str> = dialog
+            .candidates()
+            .iter()
+            .map(|candidate| candidate.name.as_str())
+            .collect();
+        assert_eq!(names, ["sub", "alpha.ftml", "beta.md"]);
+        assert!(dialog.candidates()[0].is_dir);
+
+        let dialog = dialog_with_input("tests/fixtures/b");
+        let names: Vec<&str> = dialog
+            .candidates()
+            .iter()
+            .map(|candidate| candidate.name.as_str())
+            .collect();
+        assert_eq!(names, ["beta.md"]);
+    }
+
+    #[test]
+    fn tab_completes_unique_match_and_descends_into_directories() {
+        let mut dialog = dialog_with_input("tests/fixtures/al");
+        dialog.complete();
+        assert_eq!(dialog.input(), "tests/fixtures/alpha.ftml");
+
+        let mut dialog = dialog_with_input("tests/fixtures/su");
+        dialog.complete();
+        assert_eq!(dialog.input(), "tests/fixtures/sub/");
+        assert_eq!(dialog.candidates().len(), 3); // the nested* fixtures
+    }
+
+    #[test]
+    fn tab_completes_to_longest_common_prefix() {
+        let mut dialog = dialog_with_input("tests/fixtures/sub/nested-");
+        dialog.complete();
+        assert_eq!(dialog.input(), "tests/fixtures/sub/nested-cop");
+        assert_eq!(dialog.candidates().len(), 2);
+    }
+
+    #[test]
+    fn enter_descends_into_typed_directory() {
+        let mut dialog = dialog_with_input("tests/fixtures");
+        assert!(matches!(dialog.enter(), FileDialogResult::Pending));
+        assert_eq!(dialog.input(), "tests/fixtures/");
+    }
+
+    #[test]
+    fn enter_accepts_selected_file() {
+        let mut dialog = dialog_with_input("tests/fixtures/alpha");
+        dialog.move_selection(1);
+        match dialog.enter() {
+            FileDialogResult::Accept(path) => {
+                assert_eq!(path, PathBuf::from("tests/fixtures/alpha.ftml"));
+            }
+            FileDialogResult::Pending => panic!("expected the selected file to be accepted"),
+        }
+    }
+
+    #[test]
+    fn selection_cycles_through_input_focus() {
+        let mut dialog = dialog_with_input("tests/fixtures/");
+        assert_eq!(dialog.selected(), None);
+        dialog.move_selection(1);
+        assert_eq!(dialog.selected(), Some(0));
+        dialog.move_selection(-1);
+        assert_eq!(dialog.selected(), None);
+        dialog.move_selection(-1);
+        assert_eq!(dialog.selected(), Some(2));
+        dialog.move_selection(1);
+        assert_eq!(dialog.selected(), None);
+    }
+
+    #[test]
+    fn editing_input_resets_selection_and_confirmation() {
+        let mut dialog = dialog_with_input("tests/fixtures/");
+        dialog.move_selection(1);
+        dialog.set_pending_confirm(PathBuf::from("tests/fixtures/alpha.ftml"));
+        dialog.insert_char('a');
+        assert_eq!(dialog.selected(), None);
+        assert_eq!(dialog.pending_confirm(), None);
+        assert_eq!(dialog.input(), "tests/fixtures/a");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 pub mod app;
 pub mod editor;
 pub mod editor_display;
+pub mod file_dialog;
 pub mod menu_bar;
 pub mod render;
 pub mod theme;

--- a/src/menu_bar.rs
+++ b/src/menu_bar.rs
@@ -9,6 +9,7 @@
 /// An application-level command reachable from the menu bar.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum AppAction {
+    New,
     Open,
     Save,
     SaveAs,
@@ -71,6 +72,7 @@ pub const MENU_BAR: &[MenuDef] = &[
         title: "File",
         accel_index: 0,
         entries: &[
+            item("New", Some("^N"), AppAction::New),
             item("Open...", Some("^O"), AppAction::Open),
             MenuBarEntry::Separator,
             item("Save", Some("^S"), AppAction::Save),

--- a/src/menu_bar.rs
+++ b/src/menu_bar.rs
@@ -9,7 +9,9 @@
 /// An application-level command reachable from the menu bar.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum AppAction {
+    Open,
     Save,
+    SaveAs,
     Quit,
     Undo,
     Redo,
@@ -69,7 +71,10 @@ pub const MENU_BAR: &[MenuDef] = &[
         title: "File",
         accel_index: 0,
         entries: &[
+            item("Open...", Some("^O"), AppAction::Open),
+            MenuBarEntry::Separator,
             item("Save", Some("^S"), AppAction::Save),
+            item("Save As...", None, AppAction::SaveAs),
             MenuBarEntry::Separator,
             item("Quit", Some("^Q"), AppAction::Quit),
         ],

--- a/src/snapshot_tests.rs
+++ b/src/snapshot_tests.rs
@@ -432,9 +432,88 @@ fn esc_cancels_file_dialog() {
 /// Open the Save As dialog through the File menu.
 fn open_save_as_dialog(app: &mut TestApp) {
     app.key_with(KeyCode::Char('f'), KeyModifiers::ALT);
+    app.key(KeyCode::Down); // Open...
     app.key(KeyCode::Down); // Save
     app.key(KeyCode::Down); // Save As...
     app.key(KeyCode::Enter);
+}
+
+#[test]
+fn untitled_document_shows_untitled_in_status_bar() {
+    let mut app = TestApp::untitled(WIDTH, HEIGHT, sample_document());
+    assert_svg("untitled_status_bar", &mut app);
+}
+
+#[test]
+fn ctrl_n_replaces_document_with_untitled_one() {
+    let mut app = sample_app();
+    app.ctrl('n');
+    assert_svg("new_document", &mut app);
+}
+
+#[test]
+fn ctrl_n_asks_before_discarding_unsaved_changes() {
+    let mut app = sample_app();
+    app.type_text("Summer ");
+    app.ctrl('n');
+    assert!(
+        app.svg().contains("Summer"),
+        "the first Ctrl+N must only warn, not discard the document"
+    );
+    assert_svg("new_document_unsaved_warning", &mut app);
+    app.ctrl('n');
+    assert_svg("new_document_after_confirm", &mut app);
+}
+
+#[test]
+fn typing_after_new_document_warning_requires_another_warning() {
+    let mut app = sample_app();
+    app.type_text("Summer ");
+    app.ctrl('n');
+    // Editing after the warning invalidates it: the next Ctrl+N warns again.
+    app.type_text("and Winter ");
+    app.ctrl('n');
+    assert!(
+        app.svg().contains("Winter"),
+        "Ctrl+N after further edits must warn again instead of discarding"
+    );
+}
+
+#[test]
+fn saving_untitled_document_opens_save_as_dialog() {
+    let dir = std::env::temp_dir().join(format!("pure-untitled-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).expect("create temp dir");
+    let target = dir.join("named.ftml");
+    let _ = std::fs::remove_file(&target);
+
+    let mut app = TestApp::untitled(WIDTH, HEIGHT, sample_document());
+    app.ctrl('s');
+    assert!(
+        app.svg().contains("Save As"),
+        "Ctrl+S on an untitled document must open the Save As dialog"
+    );
+
+    app.type_text(target.to_str().expect("utf-8 temp path"));
+    app.key(KeyCode::Enter);
+    let contents = std::fs::read_to_string(&target).expect("file saved under the typed name");
+    assert!(
+        contents.contains("Packing List"),
+        "saved file must contain the document, got: {contents}"
+    );
+
+    // Now that the document has a name, Ctrl+S saves directly.
+    app.type_text("More ");
+    app.ctrl('s');
+    assert!(
+        !app.svg().contains("Save As"),
+        "Ctrl+S on a named document must save without a dialog"
+    );
+    let contents = std::fs::read_to_string(&target).expect("file saved again");
+    assert!(
+        contents.contains("More"),
+        "the second save must write the edited document, got: {contents}"
+    );
+    std::fs::remove_dir_all(&dir).ok();
 }
 
 #[test]

--- a/src/snapshot_tests.rs
+++ b/src/snapshot_tests.rs
@@ -380,6 +380,113 @@ fn paste_preserves_inline_styles() {
 }
 
 #[test]
+fn ctrl_o_opens_file_dialog_and_lists_directory() {
+    let mut app = sample_app();
+    app.ctrl('o');
+    app.type_text("tests/fixtures/");
+    assert_svg("file_dialog_lists_directory", &mut app);
+}
+
+#[test]
+fn file_dialog_tab_completes_path() {
+    let mut app = sample_app();
+    app.ctrl('o');
+    app.type_text("tests/fixtures/al");
+    app.key(KeyCode::Tab);
+    assert_svg("file_dialog_tab_completed", &mut app);
+}
+
+#[test]
+fn open_dialog_loads_selected_file() {
+    let mut app = sample_app();
+    app.ctrl('o');
+    app.type_text("tests/fixtures/");
+    // Highlight alpha.ftml (the entry after the sub/ directory).
+    app.key(KeyCode::Down);
+    app.key(KeyCode::Down);
+    app.key(KeyCode::Enter);
+    assert_svg("file_dialog_opened_file", &mut app);
+}
+
+#[test]
+fn open_dialog_asks_before_discarding_unsaved_changes() {
+    let mut app = sample_app();
+    app.type_text("Summer ");
+    app.ctrl('o');
+    app.type_text("tests/fixtures/beta.md");
+    app.key(KeyCode::Enter);
+    assert_svg("file_dialog_unsaved_changes_warning", &mut app);
+    app.key(KeyCode::Enter);
+    assert_svg("file_dialog_discarded_and_opened", &mut app);
+}
+
+#[test]
+fn esc_cancels_file_dialog() {
+    let mut app = sample_app();
+    app.ctrl('o');
+    app.key(KeyCode::Esc);
+    app.type_text("Summer ");
+    assert_svg("file_dialog_cancelled", &mut app);
+}
+
+/// Open the Save As dialog through the File menu.
+fn open_save_as_dialog(app: &mut TestApp) {
+    app.key_with(KeyCode::Char('f'), KeyModifiers::ALT);
+    app.key(KeyCode::Down); // Save
+    app.key(KeyCode::Down); // Save As...
+    app.key(KeyCode::Enter);
+}
+
+#[test]
+fn save_as_via_menu_writes_new_file() {
+    let dir = std::env::temp_dir().join(format!("pure-save-as-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).expect("create temp dir");
+    let target = dir.join("saved.ftml");
+    let _ = std::fs::remove_file(&target);
+
+    let mut app = sample_app();
+    open_save_as_dialog(&mut app);
+    // Replace the suggested "test.ftml" with the target path.
+    app.ctrl('w');
+    app.type_text(target.to_str().expect("utf-8 temp path"));
+    app.key(KeyCode::Enter);
+
+    let contents = std::fs::read_to_string(&target).expect("file saved under the new name");
+    assert!(
+        contents.contains("Packing List"),
+        "saved file must contain the document, got: {contents}"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn save_as_requires_confirmation_before_overwriting() {
+    let dir = std::env::temp_dir().join(format!("pure-overwrite-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).expect("create temp dir");
+    let target = dir.join("existing.md");
+    std::fs::write(&target, "old contents").expect("seed existing file");
+
+    let mut app = sample_app();
+    open_save_as_dialog(&mut app);
+    app.ctrl('w');
+    app.type_text(target.to_str().expect("utf-8 temp path"));
+    app.key(KeyCode::Enter);
+    assert_eq!(
+        std::fs::read_to_string(&target).expect("file readable"),
+        "old contents",
+        "the first Enter must only warn, not overwrite"
+    );
+
+    app.key(KeyCode::Enter);
+    let contents = std::fs::read_to_string(&target).expect("file overwritten");
+    assert!(
+        contents.starts_with("# Packing List"),
+        "saving as .md must write Markdown, got: {contents}"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
 fn paste_rebuilds_cut_list_items() {
     let mut app = sample_app();
     // Select both list items and cut them.

--- a/src/snapshots/file_dialog_cancelled.snap
+++ b/src/snapshots/file_dialog_cancelled.snap
@@ -1,0 +1,5 @@
+---
+source: src/snapshot_tests.rs
+extension: svg
+snapshot_kind: binary
+---

--- a/src/snapshots/file_dialog_cancelled.snap.svg
+++ b/src/snapshots/file_dialog_cancelled.snap.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="360" viewBox="0 0 720 360" font-family="'DejaVu Sans Mono', Menlo, Consolas, monospace" font-size="16px">
+<rect width="100%" height="100%" fill="#101010"/>
+<text x="250" y="75" fill="#d8d8d8" textLength="190" lengthAdjust="spacingAndGlyphs" xml:space="preserve" font-weight="bold">Summer Packing List</text>
+<text x="0" y="155" fill="#d8d8d8" textLength="110" lengthAdjust="spacingAndGlyphs" xml:space="preserve">  Pack the </text>
+<text x="110" y="155" fill="#d8d8d8" textLength="100" lengthAdjust="spacingAndGlyphs" xml:space="preserve" font-weight="bold">essentials</text>
+<text x="210" y="155" fill="#d8d8d8" textLength="120" lengthAdjust="spacingAndGlyphs" xml:space="preserve"> before the </text>
+<text x="330" y="155" fill="#d8d8d8" textLength="40" lengthAdjust="spacingAndGlyphs" xml:space="preserve" font-style="italic">long</text>
+<text x="370" y="155" fill="#d8d8d8" textLength="350" lengthAdjust="spacingAndGlyphs" xml:space="preserve"> trip.                             </text>
+<text x="20" y="195" fill="#e5e5e5" textLength="20" lengthAdjust="spacingAndGlyphs" xml:space="preserve" opacity="0.6">• </text>
+<text x="40" y="195" fill="#d8d8d8" textLength="680" lengthAdjust="spacingAndGlyphs" xml:space="preserve">Passport                                                            </text>
+<text x="20" y="235" fill="#e5e5e5" textLength="20" lengthAdjust="spacingAndGlyphs" xml:space="preserve" opacity="0.6">• </text>
+<text x="40" y="235" fill="#d8d8d8" textLength="680" lengthAdjust="spacingAndGlyphs" xml:space="preserve">Tickets                                                             </text>
+<text x="20" y="275" fill="#e5e5e5" textLength="20" lengthAdjust="spacingAndGlyphs" xml:space="preserve" opacity="0.6">| </text>
+<text x="40" y="275" fill="#d8d8d8" textLength="680" lengthAdjust="spacingAndGlyphs" xml:space="preserve">Travel light.                                                       </text>
+<rect x="0" y="340" width="40" height="20" fill="#2472c8"/>
+<text x="0" y="355" fill="#ffffff" textLength="40" lengthAdjust="spacingAndGlyphs" xml:space="preserve">4:8 </text>
+<rect x="40" y="340" width="100" height="20" fill="#2472c8"/>
+<text x="40" y="355" fill="#f5f543" textLength="100" lengthAdjust="spacingAndGlyphs" xml:space="preserve">test.ftml*</text>
+<rect x="140" y="340" width="580" height="20" fill="#2472c8"/>
+<text x="140" y="355" fill="#ffffff" textLength="580" lengthAdjust="spacingAndGlyphs" xml:space="preserve"> Header Lvl 1, 13 lines, 14 words F10:Menu ^S:Save ^Q:Quit</text>
+<rect x="320" y="60" width="10" height="20" fill="#ffffff" fill-opacity="0.4"/>
+</svg>

--- a/src/snapshots/file_dialog_discarded_and_opened.snap
+++ b/src/snapshots/file_dialog_discarded_and_opened.snap
@@ -1,0 +1,5 @@
+---
+source: src/snapshot_tests.rs
+extension: svg
+snapshot_kind: binary
+---

--- a/src/snapshots/file_dialog_discarded_and_opened.snap.svg
+++ b/src/snapshots/file_dialog_discarded_and_opened.snap.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="360" viewBox="0 0 720 360" font-family="'DejaVu Sans Mono', Menlo, Consolas, monospace" font-size="16px">
+<rect width="100%" height="100%" fill="#101010"/>
+<text x="330" y="75" fill="#d8d8d8" textLength="40" lengthAdjust="spacingAndGlyphs" xml:space="preserve" font-weight="bold">Beta</text>
+<text x="0" y="155" fill="#d8d8d8" textLength="720" lengthAdjust="spacingAndGlyphs" xml:space="preserve">  Hello from the beta fixture.                                          </text>
+<rect x="0" y="340" width="720" height="20" fill="#2472c8"/>
+<text x="0" y="355" fill="#ffffff" textLength="720" lengthAdjust="spacingAndGlyphs" xml:space="preserve">4:1 Opened tests/fixtures/beta.md                                       </text>
+<rect x="330" y="60" width="10" height="20" fill="#ffffff" fill-opacity="0.4"/>
+</svg>

--- a/src/snapshots/file_dialog_lists_directory.snap
+++ b/src/snapshots/file_dialog_lists_directory.snap
@@ -1,0 +1,5 @@
+---
+source: src/snapshot_tests.rs
+extension: svg
+snapshot_kind: binary
+---

--- a/src/snapshots/file_dialog_lists_directory.snap.svg
+++ b/src/snapshots/file_dialog_lists_directory.snap.svg
@@ -1,0 +1,61 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="360" viewBox="0 0 720 360" font-family="'DejaVu Sans Mono', Menlo, Consolas, monospace" font-size="16px">
+<rect width="100%" height="100%" fill="#101010"/>
+<text x="290" y="75" fill="#d8d8d8" textLength="120" lengthAdjust="spacingAndGlyphs" xml:space="preserve" font-weight="bold">Packing List</text>
+<rect x="60" y="100" width="600" height="20" fill="#000000"/>
+<text x="60" y="115" fill="#e5e5e5" textLength="600" lengthAdjust="spacingAndGlyphs" xml:space="preserve">┌Open File─────────────────────────────────────────────────┐</text>
+<rect x="60" y="120" width="10" height="20" fill="#000000"/>
+<text x="60" y="135" fill="#e5e5e5" textLength="10" lengthAdjust="spacingAndGlyphs" xml:space="preserve">│</text>
+<rect x="70" y="120" width="580" height="20" fill="#000000"/>
+<text x="70" y="135" fill="#ffffff" textLength="580" lengthAdjust="spacingAndGlyphs" xml:space="preserve"> tests/fixtures/                                          </text>
+<rect x="650" y="120" width="10" height="20" fill="#000000"/>
+<text x="650" y="135" fill="#e5e5e5" textLength="10" lengthAdjust="spacingAndGlyphs" xml:space="preserve">│</text>
+<text x="0" y="155" fill="#d8d8d8" textLength="60" lengthAdjust="spacingAndGlyphs" xml:space="preserve">  Pack</text>
+<rect x="60" y="140" width="10" height="20" fill="#000000"/>
+<text x="60" y="155" fill="#e5e5e5" textLength="10" lengthAdjust="spacingAndGlyphs" xml:space="preserve">│</text>
+<rect x="70" y="140" width="580" height="20" fill="#000000"/>
+<text x="70" y="155" fill="#666666" textLength="580" lengthAdjust="spacingAndGlyphs" xml:space="preserve">──────────────────────────────────────────────────────────</text>
+<rect x="650" y="140" width="10" height="20" fill="#000000"/>
+<text x="650" y="155" fill="#e5e5e5" textLength="10" lengthAdjust="spacingAndGlyphs" xml:space="preserve">│</text>
+<rect x="60" y="160" width="10" height="20" fill="#000000"/>
+<text x="60" y="175" fill="#e5e5e5" textLength="10" lengthAdjust="spacingAndGlyphs" xml:space="preserve">│</text>
+<rect x="70" y="160" width="50" height="20" fill="#000000"/>
+<text x="70" y="175" fill="#ffffff" textLength="50" lengthAdjust="spacingAndGlyphs" xml:space="preserve" font-weight="bold"> sub/</text>
+<rect x="120" y="160" width="530" height="20" fill="#000000"/>
+<rect x="650" y="160" width="10" height="20" fill="#000000"/>
+<text x="650" y="175" fill="#e5e5e5" textLength="10" lengthAdjust="spacingAndGlyphs" xml:space="preserve">│</text>
+<text x="20" y="195" fill="#e5e5e5" textLength="20" lengthAdjust="spacingAndGlyphs" xml:space="preserve" opacity="0.6">• </text>
+<text x="40" y="195" fill="#d8d8d8" textLength="20" lengthAdjust="spacingAndGlyphs" xml:space="preserve">Pa</text>
+<rect x="60" y="180" width="10" height="20" fill="#000000"/>
+<text x="60" y="195" fill="#e5e5e5" textLength="10" lengthAdjust="spacingAndGlyphs" xml:space="preserve">│</text>
+<rect x="70" y="180" width="580" height="20" fill="#000000"/>
+<text x="70" y="195" fill="#ffffff" textLength="580" lengthAdjust="spacingAndGlyphs" xml:space="preserve"> alpha.ftml                                               </text>
+<rect x="650" y="180" width="10" height="20" fill="#000000"/>
+<text x="650" y="195" fill="#e5e5e5" textLength="10" lengthAdjust="spacingAndGlyphs" xml:space="preserve">│</text>
+<rect x="60" y="200" width="10" height="20" fill="#000000"/>
+<text x="60" y="215" fill="#e5e5e5" textLength="10" lengthAdjust="spacingAndGlyphs" xml:space="preserve">│</text>
+<rect x="70" y="200" width="580" height="20" fill="#000000"/>
+<text x="70" y="215" fill="#ffffff" textLength="580" lengthAdjust="spacingAndGlyphs" xml:space="preserve"> beta.md                                                  </text>
+<rect x="650" y="200" width="10" height="20" fill="#000000"/>
+<text x="650" y="215" fill="#e5e5e5" textLength="10" lengthAdjust="spacingAndGlyphs" xml:space="preserve">│</text>
+<text x="20" y="235" fill="#e5e5e5" textLength="20" lengthAdjust="spacingAndGlyphs" xml:space="preserve" opacity="0.6">• </text>
+<text x="40" y="235" fill="#d8d8d8" textLength="20" lengthAdjust="spacingAndGlyphs" xml:space="preserve">Ti</text>
+<rect x="60" y="220" width="10" height="20" fill="#000000"/>
+<text x="60" y="235" fill="#e5e5e5" textLength="10" lengthAdjust="spacingAndGlyphs" xml:space="preserve">│</text>
+<rect x="70" y="220" width="10" height="20" fill="#000000"/>
+<rect x="80" y="220" width="390" height="20" fill="#000000"/>
+<text x="80" y="235" fill="#666666" textLength="390" lengthAdjust="spacingAndGlyphs" xml:space="preserve">Tab: complete  Enter: open  Esc: cancel</text>
+<rect x="470" y="220" width="180" height="20" fill="#000000"/>
+<rect x="650" y="220" width="10" height="20" fill="#000000"/>
+<text x="650" y="235" fill="#e5e5e5" textLength="10" lengthAdjust="spacingAndGlyphs" xml:space="preserve">│</text>
+<rect x="60" y="240" width="600" height="20" fill="#000000"/>
+<text x="60" y="255" fill="#e5e5e5" textLength="600" lengthAdjust="spacingAndGlyphs" xml:space="preserve">└──────────────────────────────────────────────────────────┘</text>
+<text x="20" y="275" fill="#e5e5e5" textLength="20" lengthAdjust="spacingAndGlyphs" xml:space="preserve" opacity="0.6">| </text>
+<text x="40" y="275" fill="#d8d8d8" textLength="680" lengthAdjust="spacingAndGlyphs" xml:space="preserve">Travel light.                                                       </text>
+<rect x="0" y="340" width="40" height="20" fill="#2472c8"/>
+<text x="0" y="355" fill="#ffffff" textLength="40" lengthAdjust="spacingAndGlyphs" xml:space="preserve">4:1 </text>
+<rect x="40" y="340" width="90" height="20" fill="#2472c8"/>
+<text x="40" y="355" fill="#f5f543" textLength="90" lengthAdjust="spacingAndGlyphs" xml:space="preserve">test.ftml</text>
+<rect x="130" y="340" width="590" height="20" fill="#2472c8"/>
+<text x="130" y="355" fill="#ffffff" textLength="590" lengthAdjust="spacingAndGlyphs" xml:space="preserve"> Header Lvl 1, 13 lines, 13 words  F10:Menu ^S:Save ^Q:Quit</text>
+<rect x="230" y="120" width="10" height="20" fill="#ffffff" fill-opacity="0.4"/>
+</svg>

--- a/src/snapshots/file_dialog_opened_file.snap
+++ b/src/snapshots/file_dialog_opened_file.snap
@@ -1,0 +1,5 @@
+---
+source: src/snapshot_tests.rs
+extension: svg
+snapshot_kind: binary
+---

--- a/src/snapshots/file_dialog_opened_file.snap.svg
+++ b/src/snapshots/file_dialog_opened_file.snap.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="360" viewBox="0 0 720 360" font-family="'DejaVu Sans Mono', Menlo, Consolas, monospace" font-size="16px">
+<rect width="100%" height="100%" fill="#101010"/>
+<text x="320" y="75" fill="#d8d8d8" textLength="50" lengthAdjust="spacingAndGlyphs" xml:space="preserve" font-weight="bold">Alpha</text>
+<text x="0" y="155" fill="#d8d8d8" textLength="720" lengthAdjust="spacingAndGlyphs" xml:space="preserve">  Hello from the alpha fixture.                                         </text>
+<rect x="0" y="340" width="720" height="20" fill="#2472c8"/>
+<text x="0" y="355" fill="#ffffff" textLength="720" lengthAdjust="spacingAndGlyphs" xml:space="preserve">4:1 Opened tests/fixtures/alpha.ftml                                    </text>
+<rect x="320" y="60" width="10" height="20" fill="#ffffff" fill-opacity="0.4"/>
+</svg>

--- a/src/snapshots/file_dialog_tab_completed.snap
+++ b/src/snapshots/file_dialog_tab_completed.snap
@@ -1,0 +1,5 @@
+---
+source: src/snapshot_tests.rs
+extension: svg
+snapshot_kind: binary
+---

--- a/src/snapshots/file_dialog_tab_completed.snap.svg
+++ b/src/snapshots/file_dialog_tab_completed.snap.svg
@@ -1,0 +1,48 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="360" viewBox="0 0 720 360" font-family="'DejaVu Sans Mono', Menlo, Consolas, monospace" font-size="16px">
+<rect width="100%" height="100%" fill="#101010"/>
+<text x="290" y="75" fill="#d8d8d8" textLength="120" lengthAdjust="spacingAndGlyphs" xml:space="preserve" font-weight="bold">Packing List</text>
+<rect x="60" y="120" width="600" height="20" fill="#000000"/>
+<text x="60" y="135" fill="#e5e5e5" textLength="600" lengthAdjust="spacingAndGlyphs" xml:space="preserve">┌Open File─────────────────────────────────────────────────┐</text>
+<text x="0" y="155" fill="#d8d8d8" textLength="60" lengthAdjust="spacingAndGlyphs" xml:space="preserve">  Pack</text>
+<rect x="60" y="140" width="10" height="20" fill="#000000"/>
+<text x="60" y="155" fill="#e5e5e5" textLength="10" lengthAdjust="spacingAndGlyphs" xml:space="preserve">│</text>
+<rect x="70" y="140" width="580" height="20" fill="#000000"/>
+<text x="70" y="155" fill="#ffffff" textLength="580" lengthAdjust="spacingAndGlyphs" xml:space="preserve"> tests/fixtures/alpha.ftml                                </text>
+<rect x="650" y="140" width="10" height="20" fill="#000000"/>
+<text x="650" y="155" fill="#e5e5e5" textLength="10" lengthAdjust="spacingAndGlyphs" xml:space="preserve">│</text>
+<rect x="60" y="160" width="10" height="20" fill="#000000"/>
+<text x="60" y="175" fill="#e5e5e5" textLength="10" lengthAdjust="spacingAndGlyphs" xml:space="preserve">│</text>
+<rect x="70" y="160" width="580" height="20" fill="#000000"/>
+<text x="70" y="175" fill="#666666" textLength="580" lengthAdjust="spacingAndGlyphs" xml:space="preserve">──────────────────────────────────────────────────────────</text>
+<rect x="650" y="160" width="10" height="20" fill="#000000"/>
+<text x="650" y="175" fill="#e5e5e5" textLength="10" lengthAdjust="spacingAndGlyphs" xml:space="preserve">│</text>
+<text x="20" y="195" fill="#e5e5e5" textLength="20" lengthAdjust="spacingAndGlyphs" xml:space="preserve" opacity="0.6">• </text>
+<text x="40" y="195" fill="#d8d8d8" textLength="20" lengthAdjust="spacingAndGlyphs" xml:space="preserve">Pa</text>
+<rect x="60" y="180" width="10" height="20" fill="#000000"/>
+<text x="60" y="195" fill="#e5e5e5" textLength="10" lengthAdjust="spacingAndGlyphs" xml:space="preserve">│</text>
+<rect x="70" y="180" width="580" height="20" fill="#000000"/>
+<text x="70" y="195" fill="#ffffff" textLength="580" lengthAdjust="spacingAndGlyphs" xml:space="preserve"> alpha.ftml                                               </text>
+<rect x="650" y="180" width="10" height="20" fill="#000000"/>
+<text x="650" y="195" fill="#e5e5e5" textLength="10" lengthAdjust="spacingAndGlyphs" xml:space="preserve">│</text>
+<rect x="60" y="200" width="10" height="20" fill="#000000"/>
+<text x="60" y="215" fill="#e5e5e5" textLength="10" lengthAdjust="spacingAndGlyphs" xml:space="preserve">│</text>
+<rect x="70" y="200" width="10" height="20" fill="#000000"/>
+<rect x="80" y="200" width="390" height="20" fill="#000000"/>
+<text x="80" y="215" fill="#666666" textLength="390" lengthAdjust="spacingAndGlyphs" xml:space="preserve">Tab: complete  Enter: open  Esc: cancel</text>
+<rect x="470" y="200" width="180" height="20" fill="#000000"/>
+<rect x="650" y="200" width="10" height="20" fill="#000000"/>
+<text x="650" y="215" fill="#e5e5e5" textLength="10" lengthAdjust="spacingAndGlyphs" xml:space="preserve">│</text>
+<text x="20" y="235" fill="#e5e5e5" textLength="20" lengthAdjust="spacingAndGlyphs" xml:space="preserve" opacity="0.6">• </text>
+<text x="40" y="235" fill="#d8d8d8" textLength="20" lengthAdjust="spacingAndGlyphs" xml:space="preserve">Ti</text>
+<rect x="60" y="220" width="600" height="20" fill="#000000"/>
+<text x="60" y="235" fill="#e5e5e5" textLength="600" lengthAdjust="spacingAndGlyphs" xml:space="preserve">└──────────────────────────────────────────────────────────┘</text>
+<text x="20" y="275" fill="#e5e5e5" textLength="20" lengthAdjust="spacingAndGlyphs" xml:space="preserve" opacity="0.6">| </text>
+<text x="40" y="275" fill="#d8d8d8" textLength="680" lengthAdjust="spacingAndGlyphs" xml:space="preserve">Travel light.                                                       </text>
+<rect x="0" y="340" width="40" height="20" fill="#2472c8"/>
+<text x="0" y="355" fill="#ffffff" textLength="40" lengthAdjust="spacingAndGlyphs" xml:space="preserve">4:1 </text>
+<rect x="40" y="340" width="90" height="20" fill="#2472c8"/>
+<text x="40" y="355" fill="#f5f543" textLength="90" lengthAdjust="spacingAndGlyphs" xml:space="preserve">test.ftml</text>
+<rect x="130" y="340" width="590" height="20" fill="#2472c8"/>
+<text x="130" y="355" fill="#ffffff" textLength="590" lengthAdjust="spacingAndGlyphs" xml:space="preserve"> Header Lvl 1, 13 lines, 13 words  F10:Menu ^S:Save ^Q:Quit</text>
+<rect x="330" y="140" width="10" height="20" fill="#ffffff" fill-opacity="0.4"/>
+</svg>

--- a/src/snapshots/file_dialog_unsaved_changes_warning.snap
+++ b/src/snapshots/file_dialog_unsaved_changes_warning.snap
@@ -1,0 +1,5 @@
+---
+source: src/snapshot_tests.rs
+extension: svg
+snapshot_kind: binary
+---

--- a/src/snapshots/file_dialog_unsaved_changes_warning.snap.svg
+++ b/src/snapshots/file_dialog_unsaved_changes_warning.snap.svg
@@ -1,0 +1,48 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="360" viewBox="0 0 720 360" font-family="'DejaVu Sans Mono', Menlo, Consolas, monospace" font-size="16px">
+<rect width="100%" height="100%" fill="#101010"/>
+<text x="250" y="75" fill="#d8d8d8" textLength="190" lengthAdjust="spacingAndGlyphs" xml:space="preserve" font-weight="bold">Summer Packing List</text>
+<rect x="60" y="120" width="600" height="20" fill="#000000"/>
+<text x="60" y="135" fill="#e5e5e5" textLength="600" lengthAdjust="spacingAndGlyphs" xml:space="preserve">┌Open File─────────────────────────────────────────────────┐</text>
+<text x="0" y="155" fill="#d8d8d8" textLength="60" lengthAdjust="spacingAndGlyphs" xml:space="preserve">  Pack</text>
+<rect x="60" y="140" width="10" height="20" fill="#000000"/>
+<text x="60" y="155" fill="#e5e5e5" textLength="10" lengthAdjust="spacingAndGlyphs" xml:space="preserve">│</text>
+<rect x="70" y="140" width="580" height="20" fill="#000000"/>
+<text x="70" y="155" fill="#ffffff" textLength="580" lengthAdjust="spacingAndGlyphs" xml:space="preserve"> tests/fixtures/beta.md                                   </text>
+<rect x="650" y="140" width="10" height="20" fill="#000000"/>
+<text x="650" y="155" fill="#e5e5e5" textLength="10" lengthAdjust="spacingAndGlyphs" xml:space="preserve">│</text>
+<rect x="60" y="160" width="10" height="20" fill="#000000"/>
+<text x="60" y="175" fill="#e5e5e5" textLength="10" lengthAdjust="spacingAndGlyphs" xml:space="preserve">│</text>
+<rect x="70" y="160" width="580" height="20" fill="#000000"/>
+<text x="70" y="175" fill="#666666" textLength="580" lengthAdjust="spacingAndGlyphs" xml:space="preserve">──────────────────────────────────────────────────────────</text>
+<rect x="650" y="160" width="10" height="20" fill="#000000"/>
+<text x="650" y="175" fill="#e5e5e5" textLength="10" lengthAdjust="spacingAndGlyphs" xml:space="preserve">│</text>
+<text x="20" y="195" fill="#e5e5e5" textLength="20" lengthAdjust="spacingAndGlyphs" xml:space="preserve" opacity="0.6">• </text>
+<text x="40" y="195" fill="#d8d8d8" textLength="20" lengthAdjust="spacingAndGlyphs" xml:space="preserve">Pa</text>
+<rect x="60" y="180" width="10" height="20" fill="#000000"/>
+<text x="60" y="195" fill="#e5e5e5" textLength="10" lengthAdjust="spacingAndGlyphs" xml:space="preserve">│</text>
+<rect x="70" y="180" width="580" height="20" fill="#000000"/>
+<text x="70" y="195" fill="#ffffff" textLength="580" lengthAdjust="spacingAndGlyphs" xml:space="preserve"> beta.md                                                  </text>
+<rect x="650" y="180" width="10" height="20" fill="#000000"/>
+<text x="650" y="195" fill="#e5e5e5" textLength="10" lengthAdjust="spacingAndGlyphs" xml:space="preserve">│</text>
+<rect x="60" y="200" width="10" height="20" fill="#000000"/>
+<text x="60" y="215" fill="#e5e5e5" textLength="10" lengthAdjust="spacingAndGlyphs" xml:space="preserve">│</text>
+<rect x="70" y="200" width="10" height="20" fill="#000000"/>
+<rect x="80" y="200" width="510" height="20" fill="#000000"/>
+<text x="80" y="215" fill="#f5f543" textLength="510" lengthAdjust="spacingAndGlyphs" xml:space="preserve">Unsaved changes — press Enter again to discard them</text>
+<rect x="590" y="200" width="60" height="20" fill="#000000"/>
+<rect x="650" y="200" width="10" height="20" fill="#000000"/>
+<text x="650" y="215" fill="#e5e5e5" textLength="10" lengthAdjust="spacingAndGlyphs" xml:space="preserve">│</text>
+<text x="20" y="235" fill="#e5e5e5" textLength="20" lengthAdjust="spacingAndGlyphs" xml:space="preserve" opacity="0.6">• </text>
+<text x="40" y="235" fill="#d8d8d8" textLength="20" lengthAdjust="spacingAndGlyphs" xml:space="preserve">Ti</text>
+<rect x="60" y="220" width="600" height="20" fill="#000000"/>
+<text x="60" y="235" fill="#e5e5e5" textLength="600" lengthAdjust="spacingAndGlyphs" xml:space="preserve">└──────────────────────────────────────────────────────────┘</text>
+<text x="20" y="275" fill="#e5e5e5" textLength="20" lengthAdjust="spacingAndGlyphs" xml:space="preserve" opacity="0.6">| </text>
+<text x="40" y="275" fill="#d8d8d8" textLength="680" lengthAdjust="spacingAndGlyphs" xml:space="preserve">Travel light.                                                       </text>
+<rect x="0" y="340" width="40" height="20" fill="#2472c8"/>
+<text x="0" y="355" fill="#ffffff" textLength="40" lengthAdjust="spacingAndGlyphs" xml:space="preserve">4:8 </text>
+<rect x="40" y="340" width="100" height="20" fill="#2472c8"/>
+<text x="40" y="355" fill="#f5f543" textLength="100" lengthAdjust="spacingAndGlyphs" xml:space="preserve">test.ftml*</text>
+<rect x="140" y="340" width="580" height="20" fill="#2472c8"/>
+<text x="140" y="355" fill="#ffffff" textLength="580" lengthAdjust="spacingAndGlyphs" xml:space="preserve"> Header Lvl 1, 13 lines, 14 words F10:Menu ^S:Save ^Q:Quit</text>
+<rect x="300" y="140" width="10" height="20" fill="#ffffff" fill-opacity="0.4"/>
+</svg>

--- a/src/snapshots/menu_bar_file_menu.snap.svg
+++ b/src/snapshots/menu_bar_file_menu.snap.svg
@@ -23,34 +23,51 @@
 <text x="300" y="15" fill="#f5f543" textLength="10" lengthAdjust="spacingAndGlyphs" xml:space="preserve" font-weight="bold">V</text>
 <rect x="310" y="0" width="410" height="20" fill="#2472c8"/>
 <text x="310" y="15" fill="#ffffff" textLength="410" lengthAdjust="spacingAndGlyphs" xml:space="preserve">iew                                      </text>
-<rect x="10" y="20" width="120" height="20" fill="#000000"/>
-<text x="10" y="35" fill="#e5e5e5" textLength="120" lengthAdjust="spacingAndGlyphs" xml:space="preserve">┌──────────┐</text>
+<rect x="10" y="20" width="180" height="20" fill="#000000"/>
+<text x="10" y="35" fill="#e5e5e5" textLength="180" lengthAdjust="spacingAndGlyphs" xml:space="preserve">┌────────────────┐</text>
 <rect x="10" y="40" width="10" height="20" fill="#000000"/>
 <text x="10" y="55" fill="#e5e5e5" textLength="10" lengthAdjust="spacingAndGlyphs" xml:space="preserve">│</text>
-<rect x="20" y="40" width="100" height="20" fill="#3b8eea"/>
-<text x="20" y="55" fill="#ffffff" textLength="100" lengthAdjust="spacingAndGlyphs" xml:space="preserve"> Save  ^S </text>
-<rect x="120" y="40" width="10" height="20" fill="#000000"/>
-<text x="120" y="55" fill="#e5e5e5" textLength="10" lengthAdjust="spacingAndGlyphs" xml:space="preserve">│</text>
+<rect x="20" y="40" width="160" height="20" fill="#3b8eea"/>
+<text x="20" y="55" fill="#ffffff" textLength="160" lengthAdjust="spacingAndGlyphs" xml:space="preserve"> Open...     ^O </text>
+<rect x="180" y="40" width="10" height="20" fill="#000000"/>
+<text x="180" y="55" fill="#e5e5e5" textLength="10" lengthAdjust="spacingAndGlyphs" xml:space="preserve">│</text>
 <rect x="10" y="60" width="10" height="20" fill="#000000"/>
 <text x="10" y="75" fill="#e5e5e5" textLength="10" lengthAdjust="spacingAndGlyphs" xml:space="preserve">│</text>
-<rect x="20" y="60" width="100" height="20" fill="#000000"/>
-<text x="20" y="75" fill="#666666" textLength="100" lengthAdjust="spacingAndGlyphs" xml:space="preserve">──────────</text>
-<rect x="120" y="60" width="10" height="20" fill="#000000"/>
-<text x="120" y="75" fill="#e5e5e5" textLength="10" lengthAdjust="spacingAndGlyphs" xml:space="preserve">│</text>
+<rect x="20" y="60" width="160" height="20" fill="#000000"/>
+<text x="20" y="75" fill="#666666" textLength="160" lengthAdjust="spacingAndGlyphs" xml:space="preserve">────────────────</text>
+<rect x="180" y="60" width="10" height="20" fill="#000000"/>
+<text x="180" y="75" fill="#e5e5e5" textLength="10" lengthAdjust="spacingAndGlyphs" xml:space="preserve">│</text>
 <text x="290" y="75" fill="#d8d8d8" textLength="120" lengthAdjust="spacingAndGlyphs" xml:space="preserve" font-weight="bold">Packing List</text>
 <rect x="10" y="80" width="10" height="20" fill="#000000"/>
 <text x="10" y="95" fill="#e5e5e5" textLength="10" lengthAdjust="spacingAndGlyphs" xml:space="preserve">│</text>
-<rect x="20" y="80" width="100" height="20" fill="#000000"/>
-<text x="20" y="95" fill="#ffffff" textLength="100" lengthAdjust="spacingAndGlyphs" xml:space="preserve"> Quit  ^Q </text>
-<rect x="120" y="80" width="10" height="20" fill="#000000"/>
-<text x="120" y="95" fill="#e5e5e5" textLength="10" lengthAdjust="spacingAndGlyphs" xml:space="preserve">│</text>
-<rect x="10" y="100" width="120" height="20" fill="#000000"/>
-<text x="10" y="115" fill="#e5e5e5" textLength="120" lengthAdjust="spacingAndGlyphs" xml:space="preserve">└──────────┘</text>
-<text x="0" y="155" fill="#d8d8d8" textLength="110" lengthAdjust="spacingAndGlyphs" xml:space="preserve">  Pack the </text>
-<text x="110" y="155" fill="#d8d8d8" textLength="100" lengthAdjust="spacingAndGlyphs" xml:space="preserve" font-weight="bold">essentials</text>
+<rect x="20" y="80" width="160" height="20" fill="#000000"/>
+<text x="20" y="95" fill="#ffffff" textLength="160" lengthAdjust="spacingAndGlyphs" xml:space="preserve"> Save        ^S </text>
+<rect x="180" y="80" width="10" height="20" fill="#000000"/>
+<text x="180" y="95" fill="#e5e5e5" textLength="10" lengthAdjust="spacingAndGlyphs" xml:space="preserve">│</text>
+<rect x="10" y="100" width="10" height="20" fill="#000000"/>
+<text x="10" y="115" fill="#e5e5e5" textLength="10" lengthAdjust="spacingAndGlyphs" xml:space="preserve">│</text>
+<rect x="20" y="100" width="160" height="20" fill="#000000"/>
+<text x="20" y="115" fill="#ffffff" textLength="160" lengthAdjust="spacingAndGlyphs" xml:space="preserve"> Save As...     </text>
+<rect x="180" y="100" width="10" height="20" fill="#000000"/>
+<text x="180" y="115" fill="#e5e5e5" textLength="10" lengthAdjust="spacingAndGlyphs" xml:space="preserve">│</text>
+<rect x="10" y="120" width="10" height="20" fill="#000000"/>
+<text x="10" y="135" fill="#e5e5e5" textLength="10" lengthAdjust="spacingAndGlyphs" xml:space="preserve">│</text>
+<rect x="20" y="120" width="160" height="20" fill="#000000"/>
+<text x="20" y="135" fill="#666666" textLength="160" lengthAdjust="spacingAndGlyphs" xml:space="preserve">────────────────</text>
+<rect x="180" y="120" width="10" height="20" fill="#000000"/>
+<text x="180" y="135" fill="#e5e5e5" textLength="10" lengthAdjust="spacingAndGlyphs" xml:space="preserve">│</text>
+<rect x="10" y="140" width="10" height="20" fill="#000000"/>
+<text x="10" y="155" fill="#e5e5e5" textLength="10" lengthAdjust="spacingAndGlyphs" xml:space="preserve">│</text>
+<rect x="20" y="140" width="160" height="20" fill="#000000"/>
+<text x="20" y="155" fill="#ffffff" textLength="160" lengthAdjust="spacingAndGlyphs" xml:space="preserve"> Quit        ^Q </text>
+<rect x="180" y="140" width="10" height="20" fill="#000000"/>
+<text x="180" y="155" fill="#e5e5e5" textLength="10" lengthAdjust="spacingAndGlyphs" xml:space="preserve">│</text>
+<text x="190" y="155" fill="#d8d8d8" textLength="20" lengthAdjust="spacingAndGlyphs" xml:space="preserve" font-weight="bold">ls</text>
 <text x="210" y="155" fill="#d8d8d8" textLength="120" lengthAdjust="spacingAndGlyphs" xml:space="preserve"> before the </text>
 <text x="330" y="155" fill="#d8d8d8" textLength="40" lengthAdjust="spacingAndGlyphs" xml:space="preserve" font-style="italic">long</text>
 <text x="370" y="155" fill="#d8d8d8" textLength="350" lengthAdjust="spacingAndGlyphs" xml:space="preserve"> trip.                             </text>
+<rect x="10" y="160" width="180" height="20" fill="#000000"/>
+<text x="10" y="175" fill="#e5e5e5" textLength="180" lengthAdjust="spacingAndGlyphs" xml:space="preserve">└────────────────┘</text>
 <text x="20" y="195" fill="#e5e5e5" textLength="20" lengthAdjust="spacingAndGlyphs" xml:space="preserve" opacity="0.6">• </text>
 <text x="40" y="195" fill="#d8d8d8" textLength="680" lengthAdjust="spacingAndGlyphs" xml:space="preserve">Passport                                                            </text>
 <text x="20" y="235" fill="#e5e5e5" textLength="20" lengthAdjust="spacingAndGlyphs" xml:space="preserve" opacity="0.6">• </text>

--- a/src/snapshots/menu_bar_file_menu.snap.svg
+++ b/src/snapshots/menu_bar_file_menu.snap.svg
@@ -28,48 +28,52 @@
 <rect x="10" y="40" width="10" height="20" fill="#000000"/>
 <text x="10" y="55" fill="#e5e5e5" textLength="10" lengthAdjust="spacingAndGlyphs" xml:space="preserve">│</text>
 <rect x="20" y="40" width="160" height="20" fill="#3b8eea"/>
-<text x="20" y="55" fill="#ffffff" textLength="160" lengthAdjust="spacingAndGlyphs" xml:space="preserve"> Open...     ^O </text>
+<text x="20" y="55" fill="#ffffff" textLength="160" lengthAdjust="spacingAndGlyphs" xml:space="preserve"> New         ^N </text>
 <rect x="180" y="40" width="10" height="20" fill="#000000"/>
 <text x="180" y="55" fill="#e5e5e5" textLength="10" lengthAdjust="spacingAndGlyphs" xml:space="preserve">│</text>
 <rect x="10" y="60" width="10" height="20" fill="#000000"/>
 <text x="10" y="75" fill="#e5e5e5" textLength="10" lengthAdjust="spacingAndGlyphs" xml:space="preserve">│</text>
 <rect x="20" y="60" width="160" height="20" fill="#000000"/>
-<text x="20" y="75" fill="#666666" textLength="160" lengthAdjust="spacingAndGlyphs" xml:space="preserve">────────────────</text>
+<text x="20" y="75" fill="#ffffff" textLength="160" lengthAdjust="spacingAndGlyphs" xml:space="preserve"> Open...     ^O </text>
 <rect x="180" y="60" width="10" height="20" fill="#000000"/>
 <text x="180" y="75" fill="#e5e5e5" textLength="10" lengthAdjust="spacingAndGlyphs" xml:space="preserve">│</text>
 <text x="290" y="75" fill="#d8d8d8" textLength="120" lengthAdjust="spacingAndGlyphs" xml:space="preserve" font-weight="bold">Packing List</text>
 <rect x="10" y="80" width="10" height="20" fill="#000000"/>
 <text x="10" y="95" fill="#e5e5e5" textLength="10" lengthAdjust="spacingAndGlyphs" xml:space="preserve">│</text>
 <rect x="20" y="80" width="160" height="20" fill="#000000"/>
-<text x="20" y="95" fill="#ffffff" textLength="160" lengthAdjust="spacingAndGlyphs" xml:space="preserve"> Save        ^S </text>
+<text x="20" y="95" fill="#666666" textLength="160" lengthAdjust="spacingAndGlyphs" xml:space="preserve">────────────────</text>
 <rect x="180" y="80" width="10" height="20" fill="#000000"/>
 <text x="180" y="95" fill="#e5e5e5" textLength="10" lengthAdjust="spacingAndGlyphs" xml:space="preserve">│</text>
 <rect x="10" y="100" width="10" height="20" fill="#000000"/>
 <text x="10" y="115" fill="#e5e5e5" textLength="10" lengthAdjust="spacingAndGlyphs" xml:space="preserve">│</text>
 <rect x="20" y="100" width="160" height="20" fill="#000000"/>
-<text x="20" y="115" fill="#ffffff" textLength="160" lengthAdjust="spacingAndGlyphs" xml:space="preserve"> Save As...     </text>
+<text x="20" y="115" fill="#ffffff" textLength="160" lengthAdjust="spacingAndGlyphs" xml:space="preserve"> Save        ^S </text>
 <rect x="180" y="100" width="10" height="20" fill="#000000"/>
 <text x="180" y="115" fill="#e5e5e5" textLength="10" lengthAdjust="spacingAndGlyphs" xml:space="preserve">│</text>
 <rect x="10" y="120" width="10" height="20" fill="#000000"/>
 <text x="10" y="135" fill="#e5e5e5" textLength="10" lengthAdjust="spacingAndGlyphs" xml:space="preserve">│</text>
 <rect x="20" y="120" width="160" height="20" fill="#000000"/>
-<text x="20" y="135" fill="#666666" textLength="160" lengthAdjust="spacingAndGlyphs" xml:space="preserve">────────────────</text>
+<text x="20" y="135" fill="#ffffff" textLength="160" lengthAdjust="spacingAndGlyphs" xml:space="preserve"> Save As...     </text>
 <rect x="180" y="120" width="10" height="20" fill="#000000"/>
 <text x="180" y="135" fill="#e5e5e5" textLength="10" lengthAdjust="spacingAndGlyphs" xml:space="preserve">│</text>
 <rect x="10" y="140" width="10" height="20" fill="#000000"/>
 <text x="10" y="155" fill="#e5e5e5" textLength="10" lengthAdjust="spacingAndGlyphs" xml:space="preserve">│</text>
 <rect x="20" y="140" width="160" height="20" fill="#000000"/>
-<text x="20" y="155" fill="#ffffff" textLength="160" lengthAdjust="spacingAndGlyphs" xml:space="preserve"> Quit        ^Q </text>
+<text x="20" y="155" fill="#666666" textLength="160" lengthAdjust="spacingAndGlyphs" xml:space="preserve">────────────────</text>
 <rect x="180" y="140" width="10" height="20" fill="#000000"/>
 <text x="180" y="155" fill="#e5e5e5" textLength="10" lengthAdjust="spacingAndGlyphs" xml:space="preserve">│</text>
 <text x="190" y="155" fill="#d8d8d8" textLength="20" lengthAdjust="spacingAndGlyphs" xml:space="preserve" font-weight="bold">ls</text>
 <text x="210" y="155" fill="#d8d8d8" textLength="120" lengthAdjust="spacingAndGlyphs" xml:space="preserve"> before the </text>
 <text x="330" y="155" fill="#d8d8d8" textLength="40" lengthAdjust="spacingAndGlyphs" xml:space="preserve" font-style="italic">long</text>
 <text x="370" y="155" fill="#d8d8d8" textLength="350" lengthAdjust="spacingAndGlyphs" xml:space="preserve"> trip.                             </text>
-<rect x="10" y="160" width="180" height="20" fill="#000000"/>
-<text x="10" y="175" fill="#e5e5e5" textLength="180" lengthAdjust="spacingAndGlyphs" xml:space="preserve">└────────────────┘</text>
-<text x="20" y="195" fill="#e5e5e5" textLength="20" lengthAdjust="spacingAndGlyphs" xml:space="preserve" opacity="0.6">• </text>
-<text x="40" y="195" fill="#d8d8d8" textLength="680" lengthAdjust="spacingAndGlyphs" xml:space="preserve">Passport                                                            </text>
+<rect x="10" y="160" width="10" height="20" fill="#000000"/>
+<text x="10" y="175" fill="#e5e5e5" textLength="10" lengthAdjust="spacingAndGlyphs" xml:space="preserve">│</text>
+<rect x="20" y="160" width="160" height="20" fill="#000000"/>
+<text x="20" y="175" fill="#ffffff" textLength="160" lengthAdjust="spacingAndGlyphs" xml:space="preserve"> Quit        ^Q </text>
+<rect x="180" y="160" width="10" height="20" fill="#000000"/>
+<text x="180" y="175" fill="#e5e5e5" textLength="10" lengthAdjust="spacingAndGlyphs" xml:space="preserve">│</text>
+<rect x="10" y="180" width="180" height="20" fill="#000000"/>
+<text x="10" y="195" fill="#e5e5e5" textLength="180" lengthAdjust="spacingAndGlyphs" xml:space="preserve">└────────────────┘</text>
 <text x="20" y="235" fill="#e5e5e5" textLength="20" lengthAdjust="spacingAndGlyphs" xml:space="preserve" opacity="0.6">• </text>
 <text x="40" y="235" fill="#d8d8d8" textLength="680" lengthAdjust="spacingAndGlyphs" xml:space="preserve">Tickets                                                             </text>
 <text x="20" y="275" fill="#e5e5e5" textLength="20" lengthAdjust="spacingAndGlyphs" xml:space="preserve" opacity="0.6">| </text>

--- a/src/snapshots/new_document.snap
+++ b/src/snapshots/new_document.snap
@@ -1,0 +1,5 @@
+---
+source: src/snapshot_tests.rs
+extension: svg
+snapshot_kind: binary
+---

--- a/src/snapshots/new_document.snap.svg
+++ b/src/snapshots/new_document.snap.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="360" viewBox="0 0 720 360" font-family="'DejaVu Sans Mono', Menlo, Consolas, monospace" font-size="16px">
+<rect width="100%" height="100%" fill="#101010"/>
+<rect x="0" y="340" width="720" height="20" fill="#2472c8"/>
+<text x="0" y="355" fill="#ffffff" textLength="720" lengthAdjust="spacingAndGlyphs" xml:space="preserve">1:1 New document                                                        </text>
+<rect x="20" y="0" width="10" height="20" fill="#ffffff" fill-opacity="0.4"/>
+</svg>

--- a/src/snapshots/new_document_after_confirm.snap
+++ b/src/snapshots/new_document_after_confirm.snap
@@ -1,0 +1,5 @@
+---
+source: src/snapshot_tests.rs
+extension: svg
+snapshot_kind: binary
+---

--- a/src/snapshots/new_document_after_confirm.snap.svg
+++ b/src/snapshots/new_document_after_confirm.snap.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="360" viewBox="0 0 720 360" font-family="'DejaVu Sans Mono', Menlo, Consolas, monospace" font-size="16px">
+<rect width="100%" height="100%" fill="#101010"/>
+<rect x="0" y="340" width="720" height="20" fill="#2472c8"/>
+<text x="0" y="355" fill="#ffffff" textLength="720" lengthAdjust="spacingAndGlyphs" xml:space="preserve">1:1 New document                                                        </text>
+<rect x="20" y="0" width="10" height="20" fill="#ffffff" fill-opacity="0.4"/>
+</svg>

--- a/src/snapshots/new_document_unsaved_warning.snap
+++ b/src/snapshots/new_document_unsaved_warning.snap
@@ -1,0 +1,5 @@
+---
+source: src/snapshot_tests.rs
+extension: svg
+snapshot_kind: binary
+---

--- a/src/snapshots/new_document_unsaved_warning.snap.svg
+++ b/src/snapshots/new_document_unsaved_warning.snap.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="360" viewBox="0 0 720 360" font-family="'DejaVu Sans Mono', Menlo, Consolas, monospace" font-size="16px">
+<rect width="100%" height="100%" fill="#101010"/>
+<text x="250" y="75" fill="#d8d8d8" textLength="190" lengthAdjust="spacingAndGlyphs" xml:space="preserve" font-weight="bold">Summer Packing List</text>
+<text x="0" y="155" fill="#d8d8d8" textLength="110" lengthAdjust="spacingAndGlyphs" xml:space="preserve">  Pack the </text>
+<text x="110" y="155" fill="#d8d8d8" textLength="100" lengthAdjust="spacingAndGlyphs" xml:space="preserve" font-weight="bold">essentials</text>
+<text x="210" y="155" fill="#d8d8d8" textLength="120" lengthAdjust="spacingAndGlyphs" xml:space="preserve"> before the </text>
+<text x="330" y="155" fill="#d8d8d8" textLength="40" lengthAdjust="spacingAndGlyphs" xml:space="preserve" font-style="italic">long</text>
+<text x="370" y="155" fill="#d8d8d8" textLength="350" lengthAdjust="spacingAndGlyphs" xml:space="preserve"> trip.                             </text>
+<text x="20" y="195" fill="#e5e5e5" textLength="20" lengthAdjust="spacingAndGlyphs" xml:space="preserve" opacity="0.6">• </text>
+<text x="40" y="195" fill="#d8d8d8" textLength="680" lengthAdjust="spacingAndGlyphs" xml:space="preserve">Passport                                                            </text>
+<text x="20" y="235" fill="#e5e5e5" textLength="20" lengthAdjust="spacingAndGlyphs" xml:space="preserve" opacity="0.6">• </text>
+<text x="40" y="235" fill="#d8d8d8" textLength="680" lengthAdjust="spacingAndGlyphs" xml:space="preserve">Tickets                                                             </text>
+<text x="20" y="275" fill="#e5e5e5" textLength="20" lengthAdjust="spacingAndGlyphs" xml:space="preserve" opacity="0.6">| </text>
+<text x="40" y="275" fill="#d8d8d8" textLength="680" lengthAdjust="spacingAndGlyphs" xml:space="preserve">Travel light.                                                       </text>
+<rect x="0" y="340" width="720" height="20" fill="#2472c8"/>
+<text x="0" y="355" fill="#ffffff" textLength="720" lengthAdjust="spacingAndGlyphs" xml:space="preserve">4:8 Unsaved changes — select New again to discard them                  </text>
+<rect x="320" y="60" width="10" height="20" fill="#ffffff" fill-opacity="0.4"/>
+</svg>

--- a/src/snapshots/untitled_status_bar.snap
+++ b/src/snapshots/untitled_status_bar.snap
@@ -1,0 +1,5 @@
+---
+source: src/snapshot_tests.rs
+extension: svg
+snapshot_kind: binary
+---

--- a/src/snapshots/untitled_status_bar.snap.svg
+++ b/src/snapshots/untitled_status_bar.snap.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="360" viewBox="0 0 720 360" font-family="'DejaVu Sans Mono', Menlo, Consolas, monospace" font-size="16px">
+<rect width="100%" height="100%" fill="#101010"/>
+<text x="290" y="75" fill="#d8d8d8" textLength="120" lengthAdjust="spacingAndGlyphs" xml:space="preserve" font-weight="bold">Packing List</text>
+<text x="0" y="155" fill="#d8d8d8" textLength="110" lengthAdjust="spacingAndGlyphs" xml:space="preserve">  Pack the </text>
+<text x="110" y="155" fill="#d8d8d8" textLength="100" lengthAdjust="spacingAndGlyphs" xml:space="preserve" font-weight="bold">essentials</text>
+<text x="210" y="155" fill="#d8d8d8" textLength="120" lengthAdjust="spacingAndGlyphs" xml:space="preserve"> before the </text>
+<text x="330" y="155" fill="#d8d8d8" textLength="40" lengthAdjust="spacingAndGlyphs" xml:space="preserve" font-style="italic">long</text>
+<text x="370" y="155" fill="#d8d8d8" textLength="350" lengthAdjust="spacingAndGlyphs" xml:space="preserve"> trip.                             </text>
+<text x="20" y="195" fill="#e5e5e5" textLength="20" lengthAdjust="spacingAndGlyphs" xml:space="preserve" opacity="0.6">• </text>
+<text x="40" y="195" fill="#d8d8d8" textLength="680" lengthAdjust="spacingAndGlyphs" xml:space="preserve">Passport                                                            </text>
+<text x="20" y="235" fill="#e5e5e5" textLength="20" lengthAdjust="spacingAndGlyphs" xml:space="preserve" opacity="0.6">• </text>
+<text x="40" y="235" fill="#d8d8d8" textLength="680" lengthAdjust="spacingAndGlyphs" xml:space="preserve">Tickets                                                             </text>
+<text x="20" y="275" fill="#e5e5e5" textLength="20" lengthAdjust="spacingAndGlyphs" xml:space="preserve" opacity="0.6">| </text>
+<text x="40" y="275" fill="#d8d8d8" textLength="680" lengthAdjust="spacingAndGlyphs" xml:space="preserve">Travel light.                                                       </text>
+<rect x="0" y="340" width="40" height="20" fill="#2472c8"/>
+<text x="0" y="355" fill="#ffffff" textLength="40" lengthAdjust="spacingAndGlyphs" xml:space="preserve">4:1 </text>
+<rect x="40" y="340" width="80" height="20" fill="#2472c8"/>
+<text x="40" y="355" fill="#f5f543" textLength="80" lengthAdjust="spacingAndGlyphs" xml:space="preserve">Untitled</text>
+<rect x="120" y="340" width="600" height="20" fill="#2472c8"/>
+<text x="120" y="355" fill="#ffffff" textLength="600" lengthAdjust="spacingAndGlyphs" xml:space="preserve"> Header Lvl 1, 13 lines, 13 words   F10:Menu ^S:Save ^Q:Quit</text>
+<rect x="290" y="60" width="10" height="20" fill="#ffffff" fill-opacity="0.4"/>
+</svg>

--- a/src/test_harness.rs
+++ b/src/test_harness.rs
@@ -76,6 +76,16 @@ impl TestApp {
     /// Like [`TestApp::new`], but with a custom file path (shown in the
     /// status bar).
     pub fn with_path(width: u16, height: u16, document: Document, path: PathBuf) -> Self {
+        Self::build(width, height, document, Some(path))
+    }
+
+    /// Like [`TestApp::new`], but untitled — no backing file, as when Pure
+    /// is started without an argument.
+    pub fn untitled(width: u16, height: u16, document: Document) -> Self {
+        Self::build(width, height, document, None)
+    }
+
+    fn build(width: u16, height: u16, document: Document, path: Option<PathBuf>) -> Self {
         let mut app = App::new(document, path, DocumentFormat::Ftml, None);
         app.set_interactive(false);
         let terminal = Terminal::new(TestBackend::new(width, height)).expect("test terminal");

--- a/tests/fixtures/alpha.ftml
+++ b/tests/fixtures/alpha.ftml
@@ -1,0 +1,3 @@
+<h1>Alpha</h1>
+
+<p>Hello from the alpha fixture.</p>

--- a/tests/fixtures/beta.md
+++ b/tests/fixtures/beta.md
@@ -1,0 +1,3 @@
+# Beta
+
+Hello from the beta fixture.

--- a/tests/fixtures/sub/nested-copper.md
+++ b/tests/fixtures/sub/nested-copper.md
@@ -1,0 +1,1 @@
+# Nested copper

--- a/tests/fixtures/sub/nested-copy.md
+++ b/tests/fixtures/sub/nested-copy.md
@@ -1,0 +1,1 @@
+# Nested copy

--- a/tests/fixtures/sub/nested.ftml
+++ b/tests/fixtures/sub/nested.ftml
@@ -1,0 +1,3 @@
+<h1>Nested</h1>
+
+<p>Hello from the nested fixture.</p>


### PR DESCRIPTION
Open... (Ctrl+O) and Save As... in the File menu. Both show a modal file dialog: a path input with shell-style Tab completion above a live listing the directory it points into, navigable with the arrow keys (Enter into directories). Opening loads FTML or Markdown based on the and starts a new document for nonexistent paths; Save As writes the format of the new extension, so saving a `.md` copy of an `.ftml` converts it. Destructive accepts — opening over unsaved changes, another file — need a confirming second Enter.