### PR TITLE
Fix paragraph indent level changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,12 +49,6 @@ While pre-1.0, the minor version is bumped for breaking changes.
   deterministic SVG, so styling, selection, and cursor placement diff as text
   and open in any browser. (#27)
 - We're now automatically adding release notes using the CI. (#30)
-- The README's demo GIF is now recorded automatically: `examples/demo`
-  scripts a Pure session as a series of simulated key presses, renders every
-  frame through the SVG snapshot harness, and assembles the result into
-  `demo.gif` — so the demo can be re-recorded with one command whenever the
-  interface changes. Without the `recorder` feature, `cargo run --example
-  demo` plays the same script live in the terminal instead.
 
 ### Fixed
 
@@ -72,14 +66,24 @@ While pre-1.0, the minor version is bumped for breaking changes.
   behind empty list items that could not be removed. This covered several
   cases, including indenting the first item of a nested list, indenting a sole
   list item into a preceding quote, and unindenting the only child of a quote.
+  (#35)
 - The Format menu's "Indent more" is now enabled only when indenting would
-  actually do something, matching what the operation performs.
+  actually do something, matching what the operation performs. (#35)
 - Unindenting a paragraph from the middle of a list now splits the list at that
   spot instead of dropping the paragraph below the entire list, where it
-  appeared to vanish.
+  appeared to vanish. (#35)
 - Splitting a list by unindenting now redraws the whole document immediately
   with the cursor in the right place, instead of leaving the view truncated and
-  the cursor misplaced until moving away and back.
+  the cursor misplaced until moving away and back. (#35)
+
+### Misc
+
+- The README's demo GIF is now recorded automatically: `examples/demo`
+  scripts a Pure session as a series of simulated key presses, renders every
+  frame through the SVG snapshot harness, and assembles the result into
+  `demo.gif` — so the demo can be re-recorded with one command whenever the
+  interface changes. Without the `recorder` feature, `cargo run --example
+  demo` plays the same script live in the terminal instead. (#31)
 
 ## [0.4.2] - 2026-03-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,18 @@ While pre-1.0, the minor version is bumped for breaking changes.
 - Inserting or deleting a character in a line that shows reveal codes later in
   the line no longer hides those codes (while keeping the formatting) until
   the next full re-render. (#28)
+- Changing the indent level of paragraphs near nested lists no longer leaves
+  behind empty list items that could not be removed. This covered several
+  cases, including indenting the first item of a nested list, indenting a sole
+  list item into a preceding quote, and unindenting the only child of a quote.
+- The Format menu's "Indent more" is now enabled only when indenting would
+  actually do something, matching what the operation performs.
+- Unindenting a paragraph from the middle of a list now splits the list at that
+  spot instead of dropping the paragraph below the entire list, where it
+  appeared to vanish.
+- Splitting a list by unindenting now redraws the whole document immediately
+  with the cursor in the right place, instead of leaving the view truncated and
+  the cursor misplaced until moving away and back.
 
 ## [0.4.2] - 2026-03-01
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1611,6 +1611,34 @@ impl App {
         self.status_message = Some((message.to_string(), Instant::now()));
     }
 
+    /// Appends a debug dump of the document tree (with cursor position) to
+    /// `pure-tree-dump.txt` in the temp directory. Bound to F12 in dev
+    /// (debug) builds only, for diagnosing structural corruption in a live
+    /// session.
+    #[cfg(debug_assertions)]
+    fn dump_document_tree(&mut self) {
+        use std::io::Write;
+
+        let pointer = self.display.cursor_pointer();
+        let dump = crate::editor::inspect::dump_tree(self.display.document(), Some(&pointer));
+        let path = std::env::temp_dir().join("pure-tree-dump.txt");
+        let stamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        let entry = format!("==== tree dump (unix {stamp}) ====\n{dump}\n");
+        let result = fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+            .and_then(|mut file| file.write_all(entry.as_bytes()));
+        let message = match result {
+            Ok(()) => format!("Tree dumped to {}", path.display()),
+            Err(err) => format!("Tree dump failed: {err}"),
+        };
+        self.status_message = Some((message, Instant::now()));
+    }
+
     fn close_menu_bar(&mut self) {
         self.menu_bar = None;
     }
@@ -2232,6 +2260,10 @@ impl App {
                     }
                     (KeyCode::F(9), _) => {
                         self.toggle_reveal_codes();
+                    }
+                    #[cfg(debug_assertions)]
+                    (KeyCode::F(12), _) => {
+                        self.dump_document_tree();
                     }
                     (KeyCode::Char('c'), m) if m.contains(KeyModifiers::CONTROL) => {
                         // Copies the selection; without one the key is

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -15,20 +15,20 @@ pub(crate) use styles::inline_style_label;
 
 use inspect::{checklist_item_ref, paragraph_ref, span_ref, span_ref_from_item};
 use structure::{
-    IndentTargetKind, ParentRelation, append_paragraph_as_checklist_child,
-    append_paragraph_to_entry, append_paragraph_to_list, append_paragraph_to_quote,
-    break_list_entry_for_non_list_target, checklist_item_mut, convert_paragraph_into_list,
-    determine_parent_scope, ensure_checklist_item_has_content, ensure_document_initialized,
-    ensure_list_entry_has_paragraph, entry_has_multiple_paragraphs, extract_checklist_item_context,
-    extract_entry_context, find_container_indent_target, find_indent_target,
-    find_list_ancestor_path, indent_checklist_item_into_item, indent_list_entry_into_entry,
-    indent_list_entry_into_foreign_list, indent_paragraph_within_entry,
-    insert_paragraph_after_parent, is_list_type, is_single_paragraph_entry,
-    list_entry_append_target, merge_adjacent_lists, paragraph_is_empty, paragraph_mut,
-    parent_paragraph_path, promote_list_entry_to_parent, promote_single_child_into_parent,
-    remove_paragraph_by_path, span_mut, span_mut_from_item, split_paragraph_break,
-    take_checklist_item_at, take_list_entry, take_paragraph_at, unindent_checklist_item,
-    update_existing_list_type, update_paragraph_type,
+    EntryContext, IndentTarget, IndentTargetKind, ParentRelation,
+    append_paragraph_as_checklist_child, append_paragraph_to_entry, append_paragraph_to_list,
+    append_paragraph_to_quote, break_list_entry_for_non_list_target, checklist_item_mut,
+    convert_paragraph_into_list, determine_parent_scope, ensure_checklist_item_has_content,
+    ensure_document_initialized, ensure_list_entry_has_paragraph, entry_has_multiple_paragraphs,
+    extract_checklist_item_context, extract_entry_context, find_container_indent_target,
+    find_indent_target, find_list_ancestor_path, indent_checklist_item_into_item,
+    indent_list_entry_into_entry, indent_list_entry_into_foreign_list,
+    indent_paragraph_within_entry, insert_paragraph_after_parent, is_list_type,
+    is_single_paragraph_entry, list_entry_append_target, merge_adjacent_lists, paragraph_is_empty,
+    paragraph_mut, parent_paragraph_path, promote_list_entry_to_parent,
+    promote_single_child_into_parent, remove_paragraph_by_path, span_mut, span_mut_from_item,
+    split_list_entries_after, split_paragraph_break, take_checklist_item_at, take_list_entry,
+    take_paragraph_at, unindent_checklist_item, update_existing_list_type, update_paragraph_type,
 };
 
 #[derive(Clone, Debug, PartialEq, Eq, Default)]
@@ -939,13 +939,50 @@ impl DocumentEditor {
     }
 
     pub fn can_indent_more(&self) -> bool {
-        if find_indent_target(&self.document, &self.cursor.paragraph_path).is_some() {
-            return true;
+        self.indent_target_for_cursor().is_some()
+    }
+
+    /// Resolves the target an indent of the current paragraph would use, or
+    /// `None` when `indent_current_paragraph` would refuse. Shared by
+    /// `can_indent_more` and `indent_current_paragraph` so the advertised
+    /// state stays exact.
+    fn indent_target_for_cursor(&self) -> Option<IndentTarget> {
+        let path = &self.cursor.paragraph_path;
+        let mut target = find_indent_target(&self.document, path);
+        if target.is_none()
+            && let Some(ctx) = extract_entry_context(path)
+        {
+            target = Self::usable_container_indent_target(&self.document, &ctx);
         }
-        if let Some(ctx) = extract_entry_context(&self.cursor.paragraph_path) {
-            return find_container_indent_target(&self.document, &ctx.list_path).is_some();
+        let target = target?;
+
+        let pointer_is_checklist_item =
+            matches!(path.steps().last(), Some(PathStep::ChecklistItem { .. }));
+        match target.kind {
+            // Checklist items can only be nested under an item of the same
+            // checklist.
+            IndentTargetKind::ChecklistItem if pointer_is_checklist_item => {
+                let source = extract_checklist_item_context(path)?;
+                let target_ctx = extract_checklist_item_context(&target.path)?;
+                (source.checklist_path == target_ctx.checklist_path).then_some(target)
+            }
+            // These moves lift the paragraph out via `take_paragraph_at`,
+            // which cannot extract checklist items.
+            IndentTargetKind::Quote | IndentTargetKind::List if pointer_is_checklist_item => None,
+            _ => Some(target),
         }
-        false
+    }
+
+    /// Indent target for an entry that has no previous sibling, found by
+    /// walking up the ancestor chain. A `ListEntry` target found this way is
+    /// an ancestor entry that already contains the cursor — indenting into
+    /// it would tear the paragraph out of its nested list, so it is rejected.
+    fn usable_container_indent_target(
+        document: &Document,
+        ctx: &EntryContext,
+    ) -> Option<IndentTarget> {
+        find_container_indent_target(document, &ctx.list_path)
+            .filter(|target| !matches!(target.kind, IndentTargetKind::ListEntry { .. }))
     }
 
     pub fn can_indent_less(&self) -> bool {
@@ -963,13 +1000,7 @@ impl DocumentEditor {
     }
 
     pub fn indent_current_paragraph(&mut self) -> bool {
-        let mut target = find_indent_target(&self.document, &self.cursor.paragraph_path);
-        if target.is_none()
-            && let Some(ctx) = extract_entry_context(&self.cursor.paragraph_path)
-        {
-            target = find_container_indent_target(&self.document, &ctx.list_path);
-        }
-        let Some(target) = target else {
+        let Some(target) = self.indent_target_for_cursor() else {
             return false;
         };
         let pointer = self.cursor_stable_pointer();
@@ -983,15 +1014,19 @@ impl DocumentEditor {
                 indent_list_entry_into_entry(&mut self.document, &pointer, &ctx, entry_index)
             };
 
-            if let Some(new_pointer) = handled {
-                self.rebuild_segments();
-                if !self.move_to_pointer(&new_pointer)
-                    && !self.fallback_move_to_text(&new_pointer, false)
-                {
-                    self.ensure_cursor_selectable();
-                }
-                return true;
+            let Some(new_pointer) = handled else {
+                // The entry could not absorb the indent; the generic move
+                // below would tear the paragraph out of its entry and leave
+                // the list corrupted, so refuse instead.
+                return false;
+            };
+            self.rebuild_segments();
+            if !self.move_to_pointer(&new_pointer)
+                && !self.fallback_move_to_text(&new_pointer, false)
+            {
+                self.ensure_cursor_selectable();
             }
+            return true;
         }
 
         if matches!(target.kind, IndentTargetKind::ChecklistItem) {
@@ -1118,11 +1153,20 @@ impl DocumentEditor {
         let Some(paragraph) = take_paragraph_at(&mut self.document, &pointer.paragraph_path) else {
             return false;
         };
-        let Some(paragraph_path) =
+        let Some(mut paragraph_path) =
             insert_paragraph_after_parent(&mut self.document, &parent_path, paragraph)
         else {
             return false;
         };
+        // If the unindented paragraph was the parent quote's only child, the
+        // quote is now empty: remove it. The paragraph was inserted right
+        // after the parent, so it slides into the parent's old position.
+        if paragraph_ref(&self.document, &parent_path)
+            .is_some_and(|p| matches!(p, Paragraph::Quote { children } if children.is_empty()))
+        {
+            remove_paragraph_by_path(&mut self.document, &parent_path);
+            paragraph_path = parent_path;
+        }
         let mut new_pointer = pointer;
         new_pointer.paragraph_path = paragraph_path;
         self.rebuild_segments();
@@ -1142,7 +1186,7 @@ impl DocumentEditor {
             None => return false,
         };
         let PathStep::Entry {
-            entry_index: _,
+            entry_index,
             paragraph_index,
         } = *last_step
         else {
@@ -1155,6 +1199,15 @@ impl DocumentEditor {
             else {
                 return false;
             };
+            // Entries below the cursor's entry continue in a new list after
+            // the unindented paragraph, so the paragraph stays in place
+            // instead of jumping below the whole list. The tail list is
+            // inserted first; the paragraph then lands between the halves.
+            if let Some(tail_list) =
+                split_list_entries_after(&mut self.document, &list_path, entry_index)
+            {
+                insert_paragraph_after_parent(&mut self.document, &list_path, tail_list);
+            }
             let Some(paragraph_path) =
                 insert_paragraph_after_parent(&mut self.document, &list_path, paragraph)
             else {
@@ -1258,6 +1311,10 @@ impl DocumentEditor {
 
         if !is_list_type(target)
             && treat_as_singular_entry
+            // Type conversion only breaks an entry out when it has no other
+            // paragraphs; unlike unindent, it must not drag continuation
+            // paragraphs along (update_paragraph_type handles those in place).
+            && is_single_paragraph_entry(&self.document, &operation_path)
             && let Some(pointer) =
                 break_list_entry_for_non_list_target(&mut self.document, &operation_path, target)
         {

--- a/src/editor/inspect.rs
+++ b/src/editor/inspect.rs
@@ -200,6 +200,162 @@ fn text_effective_relation(
     }
 }
 
+/// Renders the document tree as an indented debug string. Structural
+/// anomalies (lists without entries, entries without paragraphs, paragraphs
+/// without spans) are flagged so they stand out when hunting tree corruption.
+/// When a cursor pointer is given, the paragraph it sits in is marked.
+pub fn dump_tree(document: &Document, cursor: Option<&CursorPointer>) -> String {
+    let mut out = String::new();
+    out.push_str(&format!(
+        "Document ({} paragraphs)\n",
+        document.paragraphs.len()
+    ));
+    for (idx, paragraph) in document.paragraphs.iter().enumerate() {
+        let mut path = ParagraphPath::new_root(idx);
+        dump_paragraph(paragraph, &mut path, 1, cursor, &mut out);
+    }
+    if let Some(pointer) = cursor {
+        out.push_str(&format!(
+            "cursor: {:?} span_path={:?} offset={}\n",
+            pointer.paragraph_path,
+            pointer.span_path.indices(),
+            pointer.offset
+        ));
+    }
+    out
+}
+
+fn dump_paragraph(
+    paragraph: &Paragraph,
+    path: &mut ParagraphPath,
+    depth: usize,
+    cursor: Option<&CursorPointer>,
+    out: &mut String,
+) {
+    let indent = "  ".repeat(depth);
+    let marker = cursor_marker(path, cursor);
+    match paragraph {
+        Paragraph::Text { content }
+        | Paragraph::Header1 { content }
+        | Paragraph::Header2 { content }
+        | Paragraph::Header3 { content }
+        | Paragraph::CodeBlock { content } => {
+            out.push_str(&format!(
+                "{indent}{}: {}{marker}\n",
+                paragraph.paragraph_type(),
+                dump_spans(content)
+            ));
+        }
+        Paragraph::Quote { children } => {
+            let warn = if children.is_empty() {
+                "  !! NO CHILDREN"
+            } else {
+                ""
+            };
+            out.push_str(&format!(
+                "{indent}Quote ({} children){warn}{marker}\n",
+                children.len()
+            ));
+            for (child_index, child) in children.iter().enumerate() {
+                path.push_child(child_index);
+                dump_paragraph(child, path, depth + 1, cursor, out);
+                path.pop();
+            }
+        }
+        Paragraph::OrderedList { entries } | Paragraph::UnorderedList { entries } => {
+            let warn = if entries.is_empty() {
+                "  !! NO ENTRIES"
+            } else {
+                ""
+            };
+            out.push_str(&format!(
+                "{indent}{} ({} entries){warn}{marker}\n",
+                paragraph.paragraph_type(),
+                entries.len()
+            ));
+            for (entry_index, entry) in entries.iter().enumerate() {
+                if entry.is_empty() {
+                    out.push_str(&format!("{indent}  entry {entry_index}  !! EMPTY ENTRY\n"));
+                    continue;
+                }
+                out.push_str(&format!(
+                    "{indent}  entry {entry_index} ({} paragraphs)\n",
+                    entry.len()
+                ));
+                for (paragraph_index, child) in entry.iter().enumerate() {
+                    path.push_entry(entry_index, paragraph_index);
+                    dump_paragraph(child, path, depth + 2, cursor, out);
+                    path.pop();
+                }
+            }
+        }
+        Paragraph::Checklist { items } => {
+            let warn = if items.is_empty() {
+                "  !! NO ITEMS"
+            } else {
+                ""
+            };
+            out.push_str(&format!(
+                "{indent}Checklist ({} items){warn}{marker}\n",
+                items.len()
+            ));
+            for (item_index, item) in items.iter().enumerate() {
+                dump_checklist_item(item, path, &[item_index], depth + 1, cursor, out);
+            }
+        }
+    }
+}
+
+fn dump_checklist_item(
+    item: &ChecklistItem,
+    path: &mut ParagraphPath,
+    indices: &[usize],
+    depth: usize,
+    cursor: Option<&CursorPointer>,
+    out: &mut String,
+) {
+    let indent = "  ".repeat(depth);
+    path.push_checklist_item(indices.to_vec());
+    let marker = cursor_marker(path, cursor);
+    path.pop();
+    let checkbox = if item.checked { "[x]" } else { "[ ]" };
+    out.push_str(&format!(
+        "{indent}item {indices:?} {checkbox} {}{marker}\n",
+        dump_spans(&item.content)
+    ));
+    for (child_index, child) in item.children.iter().enumerate() {
+        let mut child_indices = indices.to_vec();
+        child_indices.push(child_index);
+        dump_checklist_item(child, path, &child_indices, depth + 1, cursor, out);
+    }
+}
+
+fn dump_spans(spans: &[Span]) -> String {
+    if spans.is_empty() {
+        return "!! NO SPANS".to_string();
+    }
+    let mut parts = Vec::new();
+    for span in spans {
+        let mut part = String::new();
+        if span.style != InlineStyle::None {
+            part.push_str(&format!("{:?}", span.style));
+        }
+        part.push_str(&format!("{:?}", span.text));
+        if !span.children.is_empty() {
+            part.push_str(&format!("({})", dump_spans(&span.children)));
+        }
+        parts.push(part);
+    }
+    parts.join(" + ")
+}
+
+fn cursor_marker(path: &ParagraphPath, cursor: Option<&CursorPointer>) -> &'static str {
+    match cursor {
+        Some(pointer) if pointer.paragraph_path == *path => "    <== CURSOR",
+        _ => "",
+    }
+}
+
 pub fn paragraph_path_is_prefix(prefix: &ParagraphPath, target: &ParagraphPath) -> bool {
     let prefix_steps = prefix.steps();
     let target_steps = target.steps();

--- a/src/editor/structure.rs
+++ b/src/editor/structure.rs
@@ -649,9 +649,6 @@ pub(crate) fn break_list_entry_for_non_list_target(
             if entry_index >= entries.len() {
                 return None;
             }
-            if entries[entry_index].len() > 1 {
-                return None;
-            }
             let entries_after = entries.split_off(entry_index + 1);
             let selected_entry = entries.remove(entry_index);
             if paragraph_index >= selected_entry.len() {
@@ -2236,24 +2233,30 @@ fn append_checklist_child(
     }
 }
 
-fn remove_nested_list_paragraph(document: &mut Document, parent_ctx: &EntryContext) {
+/// Removes the paragraph at `parent_ctx` (an emptied nested list) from its
+/// entry. If the entry held nothing else, the entry itself is removed —
+/// padding it with an empty paragraph would create an unremovable empty
+/// item. Returns true if the entry was removed.
+fn remove_nested_list_paragraph(document: &mut Document, parent_ctx: &EntryContext) -> bool {
     let Some(list_paragraph) = paragraph_mut(document, &parent_ctx.list_path) else {
-        return;
+        return false;
     };
     let entries = match list_paragraph {
         Paragraph::OrderedList { entries } | Paragraph::UnorderedList { entries } => entries,
-        _ => return,
+        _ => return false,
     };
     if parent_ctx.entry_index >= entries.len() {
-        return;
+        return false;
     }
     let parent_entry = &mut entries[parent_ctx.entry_index];
     if parent_ctx.paragraph_index < parent_entry.len() {
         parent_entry.remove(parent_ctx.paragraph_index);
     }
     if parent_entry.is_empty() {
-        parent_entry.push(empty_text_paragraph());
+        entries.remove(parent_ctx.entry_index);
+        return true;
     }
+    false
 }
 
 pub(crate) fn take_list_entry(
@@ -2295,6 +2298,41 @@ pub(crate) fn indent_list_entry_into_foreign_list(
         return None;
     }
 
+    // If the target list's last entry already ends in a nested list of the
+    // same type, the entry joins that list. Wrapping it into a fresh list
+    // appended as its own entry would fabricate an entry without content of
+    // its own — an empty-looking item.
+    if let Some((target_entry_index, target_paragraph_index)) =
+        trailing_nested_list_position(document, target_list_path, list_type)
+    {
+        let mut steps = target_list_path.steps().to_vec();
+        steps.push(PathStep::Entry {
+            entry_index: target_entry_index,
+            paragraph_index: target_paragraph_index,
+        });
+        let nested_path = ParagraphPath::from_steps(steps.clone());
+        let entry_len = entry.len();
+        let nested = paragraph_mut(document, &nested_path)?;
+        let new_entry_index = match nested {
+            Paragraph::OrderedList { entries } | Paragraph::UnorderedList { entries } => {
+                entries.push(entry);
+                entries.len() - 1
+            }
+            _ => return None,
+        };
+        steps.push(PathStep::Entry {
+            entry_index: new_entry_index,
+            paragraph_index: source_ctx.paragraph_index.min(entry_len.saturating_sub(1)),
+        });
+        steps.extend(source_ctx.tail_steps.iter().cloned());
+        return Some(CursorPointer {
+            paragraph_path: ParagraphPath::from_steps(steps),
+            span_path: pointer.span_path.clone(),
+            offset: pointer.offset,
+            segment_kind: pointer.segment_kind,
+        });
+    }
+
     let nested_paragraph = if list_type == ParagraphType::OrderedList {
         Paragraph::OrderedList {
             entries: vec![entry.clone()],
@@ -2328,6 +2366,49 @@ pub(crate) fn indent_list_entry_into_foreign_list(
     })
 }
 
+/// Splits the list at `list_path` after `entry_index`: entries beyond it
+/// are moved into a new list of the same type, which is returned for the
+/// caller to insert. Returns `None` when there are no entries to split off.
+pub(crate) fn split_list_entries_after(
+    document: &mut Document,
+    list_path: &ParagraphPath,
+    entry_index: usize,
+) -> Option<Paragraph> {
+    let list = paragraph_mut(document, list_path)?;
+    match list {
+        Paragraph::OrderedList { entries } => {
+            (entry_index + 1 < entries.len()).then(|| Paragraph::OrderedList {
+                entries: entries.split_off(entry_index + 1),
+            })
+        }
+        Paragraph::UnorderedList { entries } => {
+            (entry_index + 1 < entries.len()).then(|| Paragraph::UnorderedList {
+                entries: entries.split_off(entry_index + 1),
+            })
+        }
+        _ => None,
+    }
+}
+
+/// If the last paragraph of `list_path`'s last entry is a nested list of
+/// `list_type`, returns its (entry_index, paragraph_index).
+fn trailing_nested_list_position(
+    document: &Document,
+    list_path: &ParagraphPath,
+    list_type: ParagraphType,
+) -> Option<(usize, usize)> {
+    let list = paragraph_ref(document, list_path)?;
+    let entries = match list {
+        Paragraph::OrderedList { entries } | Paragraph::UnorderedList { entries } => entries,
+        _ => return None,
+    };
+    let entry_index = entries.len().checked_sub(1)?;
+    let entry = entries.get(entry_index)?;
+    let paragraph_index = entry.len().checked_sub(1)?;
+    (entry.get(paragraph_index)?.paragraph_type() == list_type)
+        .then_some((entry_index, paragraph_index))
+}
+
 pub(crate) fn promote_list_entry_to_parent(
     document: &mut Document,
     pointer: &CursorPointer,
@@ -2342,8 +2423,11 @@ pub(crate) fn promote_list_entry_to_parent(
         return None;
     }
 
-    if list_became_empty {
-        remove_nested_list_paragraph(document, &parent_ctx);
+    let mut insert_index = parent_ctx.entry_index + 1;
+    if list_became_empty && remove_nested_list_paragraph(document, &parent_ctx) {
+        // The nested list was the parent entry's only content and the entry
+        // is gone; the promoted entry takes its place.
+        insert_index = parent_ctx.entry_index;
     }
 
     let list = paragraph_mut(document, &parent_ctx.list_path)?;
@@ -2351,7 +2435,7 @@ pub(crate) fn promote_list_entry_to_parent(
         Paragraph::OrderedList { entries } | Paragraph::UnorderedList { entries } => entries,
         _ => return None,
     };
-    let insert_index = (parent_ctx.entry_index + 1).min(parent_entries.len());
+    let insert_index = insert_index.min(parent_entries.len());
     parent_entries.insert(insert_index, entry);
 
     let mut steps = parent_ctx.list_path.steps().to_vec();
@@ -2496,8 +2580,6 @@ pub(crate) fn take_paragraph_at(
             let parent_path = ParagraphPath::from_steps(steps);
             let parent = paragraph_mut(document, &parent_path)?;
 
-            let is_list = is_list_type(parent.paragraph_type());
-
             let entries = match parent {
                 Paragraph::OrderedList { entries } | Paragraph::UnorderedList { entries } => {
                     entries
@@ -2517,8 +2599,10 @@ pub(crate) fn take_paragraph_at(
                 entries.remove(entry_index);
             }
 
-            if is_list && entries.is_empty() {
-                entries.push(vec![empty_text_paragraph()]);
+            if entries.is_empty() {
+                // The taken paragraph was the list's last content: drop the
+                // list rather than leaving an empty, unremovable item behind.
+                remove_paragraph_by_path(document, &parent_path);
             }
             Some(removed)
         }
@@ -2645,6 +2729,11 @@ pub(crate) fn remove_paragraph_by_path(document: &mut Document, path: &Paragraph
             entry.remove(paragraph_index);
             if entry.is_empty() {
                 entries.remove(entry_index);
+            }
+            if entries.is_empty() {
+                // Removing the last entry must not leave a list without
+                // entries behind; cascade the removal to the list itself.
+                remove_paragraph_by_path(document, &parent_path);
             }
             true
         }

--- a/src/editor_display.rs
+++ b/src/editor_display.rs
@@ -405,6 +405,19 @@ impl EditorDisplay {
     ///
     /// Returns true if an incremental update succeeded, false if a full re-render is needed.
     pub fn clear_render_cache(&mut self) -> bool {
+        // The incremental path patches root paragraphs in place. When the
+        // number of root paragraphs changed (e.g. unindenting split a list),
+        // indices have shifted and the cached layout no longer matches the
+        // document, so it must be rebuilt from scratch.
+        let cached_paragraphs = self
+            .layout
+            .as_ref()
+            .map(|layout| layout.paragraph_lines.len());
+        if cached_paragraphs != Some(self.editor.document().paragraphs.len()) {
+            self.force_full_relayout();
+            return false;
+        }
+
         // Try incremental update if we know which paragraphs changed
         if !self.last_modified_paragraphs.is_empty() {
             let paragraphs_to_update = std::mem::take(&mut self.last_modified_paragraphs);

--- a/src/editor_tests.rs
+++ b/src/editor_tests.rs
@@ -3530,3 +3530,528 @@ fn selection_fragment_does_not_modify_the_document() {
     assert_eq!(editor.document().paragraphs[0].content()[0].text, "Alpha");
     assert_eq!(editor.document().paragraphs[1].content()[0].text, "Beta");
 }
+
+// ---------------------------------------------------------------------------
+// Structural integrity of indent/unindent operations
+//
+// Regression hunting for "changing the indent level near nested lists
+// corrupts the tree" bugs: empty list entries appearing, lists left behind
+// without entries, or text being lost. The sweep test below drives every
+// indent/unindent sequence (up to length 3) from every text position of a
+// set of seed documents and asserts tree invariants after every step.
+// ---------------------------------------------------------------------------
+
+/// Walks the document and reports violations of the structural invariants
+/// the editor relies on: lists must have entries, entries must have
+/// paragraphs, quotes must have children, checklists must have items.
+fn structural_problems(document: &Document) -> Vec<String> {
+    fn walk(paragraph: &Paragraph, location: &str, problems: &mut Vec<String>) {
+        match paragraph {
+            Paragraph::Quote { children } => {
+                if children.is_empty() {
+                    problems.push(format!("{location}: quote without children"));
+                }
+                for (idx, child) in children.iter().enumerate() {
+                    walk(child, &format!("{location}>child{idx}"), problems);
+                }
+            }
+            Paragraph::OrderedList { entries } | Paragraph::UnorderedList { entries } => {
+                if entries.is_empty() {
+                    problems.push(format!("{location}: list without entries"));
+                }
+                for (idx, entry) in entries.iter().enumerate() {
+                    if entry.is_empty() {
+                        problems.push(format!("{location}>entry{idx}: empty list entry"));
+                    }
+                    for (pidx, child) in entry.iter().enumerate() {
+                        walk(child, &format!("{location}>entry{idx}.{pidx}"), problems);
+                    }
+                }
+            }
+            Paragraph::Checklist { items } if items.is_empty() => {
+                problems.push(format!("{location}: checklist without items"));
+            }
+            _ => {}
+        }
+    }
+
+    let mut problems = Vec::new();
+    for (idx, paragraph) in document.paragraphs.iter().enumerate() {
+        walk(paragraph, &format!("p{idx}"), &mut problems);
+    }
+    problems
+}
+
+/// Collects every span text in the document as a sorted multiset. Indent and
+/// unindent are pure structure operations: they must never create, delete,
+/// or alter text (the appearance of a new "" is exactly the empty-list-item
+/// bug we are hunting).
+fn document_texts(document: &Document) -> Vec<String> {
+    fn spans(list: &[Span], out: &mut Vec<String>) {
+        for span in list {
+            out.push(span.text.clone());
+            spans(&span.children, out);
+        }
+    }
+    fn items(list: &[ChecklistItem], out: &mut Vec<String>) {
+        for item in list {
+            spans(&item.content, out);
+            items(&item.children, out);
+        }
+    }
+    fn walk(paragraph: &Paragraph, out: &mut Vec<String>) {
+        spans(paragraph.content(), out);
+        for child in paragraph.children() {
+            walk(child, out);
+        }
+        for entry in paragraph.entries() {
+            for child in entry {
+                walk(child, out);
+            }
+        }
+        items(paragraph.checklist_items(), out);
+    }
+
+    let mut out = Vec::new();
+    for paragraph in &document.paragraphs {
+        walk(paragraph, &mut out);
+    }
+    out.sort();
+    out
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum IndentOp {
+    More,
+    Less,
+}
+
+fn indent_op_sequences(max_len: usize) -> Vec<Vec<IndentOp>> {
+    let mut all = Vec::new();
+    for len in 1..=max_len {
+        for bits in 0..(1usize << len) {
+            let seq = (0..len)
+                .map(|bit| {
+                    if bits & (1 << bit) != 0 {
+                        IndentOp::More
+                    } else {
+                        IndentOp::Less
+                    }
+                })
+                .collect::<Vec<_>>();
+            all.push(seq);
+        }
+    }
+    all
+}
+
+fn indent_sweep_seeds() -> Vec<(&'static str, Document)> {
+    let nested_checklist = {
+        let child = ChecklistItem::new(false).with_content(vec![Span::new_text("C1")]);
+        let first = ChecklistItem::new(false)
+            .with_content(vec![Span::new_text("T1")])
+            .with_children(vec![child]);
+        let second = ChecklistItem::new(false).with_content(vec![Span::new_text("T2")]);
+        Document::new().with_paragraphs(vec![
+            Paragraph::new_checklist().with_checklist_items(vec![first, second]),
+            text_paragraph("After"),
+        ])
+    };
+    let list_only_entry = Document::new().with_paragraphs(vec![
+        Paragraph::new_unordered_list().with_entries(vec![
+            vec![text_paragraph("A")],
+            // Degenerate but reachable: an entry holding only a nested list.
+            vec![Paragraph::new_unordered_list().with_entries(vec![vec![text_paragraph("B")]])],
+        ]),
+        text_paragraph("Tail"),
+    ]);
+
+    vec![
+        ("nested checklist then paragraph", nested_checklist),
+        ("entry holding only a nested list", list_only_entry),
+        (
+            "foreign type below mismatched nested list",
+            ftml! {
+                ul {
+                    li {
+                        p { "X" }
+                        ol { li { p { "Y" } } }
+                    }
+                }
+                ul { li { p { "Z" } } }
+            },
+        ),
+        (
+            "paragraph after list with nested item",
+            ftml! {
+                ul {
+                    li {
+                        p { "One" }
+                        ul { li { p { "Two" } } }
+                    }
+                }
+                p { "Para" }
+            },
+        ),
+        (
+            "paragraph between nested lists",
+            ftml! {
+                ul {
+                    li {
+                        p { "Alpha" }
+                        ul { li { p { "Beta" } } }
+                    }
+                    li { p { "Gamma" } }
+                }
+                p { "Middle" }
+                ul { li { p { "Delta" } } }
+            },
+        ),
+        (
+            "entry with multiple paragraphs next to nested list",
+            ftml! {
+                ul {
+                    li {
+                        p { "First" }
+                        ul { li { p { "Sub" } } }
+                        p { "Second" }
+                    }
+                    li { p { "Third" } }
+                }
+            },
+        ),
+        (
+            "deep nesting",
+            ftml! {
+                ul {
+                    li {
+                        p { "A" }
+                        ul {
+                            li {
+                                p { "B" }
+                                ul { li { p { "C" } } }
+                            }
+                        }
+                    }
+                }
+                p { "After" }
+            },
+        ),
+        (
+            "quote followed by list",
+            ftml! {
+                quote { p { "Quoted" } }
+                ul {
+                    li { p { "Item" } }
+                    li { p { "Item2" } }
+                }
+            },
+        ),
+        (
+            "quote followed by single item list",
+            ftml! {
+                quote { p { "Quoted" } }
+                ul { li { p { "Only" } } }
+            },
+        ),
+        (
+            "ordered list after unordered with nesting",
+            ftml! {
+                ul {
+                    li {
+                        p { "Bullet" }
+                        ol { li { p { "Numbered" } } }
+                    }
+                }
+                ol { li { p { "Top" } } }
+            },
+        ),
+    ]
+}
+
+/// Drives every indent/unindent sequence up to length 3 from every text
+/// position of every seed document, asserting after each single operation:
+/// 1. the tree stays structurally sound (no empty entries/lists),
+/// 2. no text is created or destroyed,
+/// 3. an operation that reports `false` did not modify the document.
+#[test]
+fn indent_unindent_sequences_keep_tree_sound() {
+    for (seed_name, seed) in indent_sweep_seeds() {
+        let seed_texts = document_texts(&seed);
+        let start_problems = structural_problems(&seed);
+        assert!(
+            start_problems.is_empty(),
+            "seed '{seed_name}' is already unsound: {start_problems:?}"
+        );
+
+        let segments = inspect::collect_segments(&seed, false);
+        for segment in &segments {
+            for ops in indent_op_sequences(4) {
+                let mut editor = DocumentEditor::new(seed.clone());
+                let pointer = CursorPointer {
+                    paragraph_path: segment.paragraph_path.clone(),
+                    span_path: segment.span_path.clone(),
+                    offset: 0,
+                    segment_kind: SegmentKind::Text,
+                };
+                if !editor.move_to_pointer(&pointer) {
+                    continue;
+                }
+
+                let mut applied: Vec<(IndentOp, bool)> = Vec::new();
+                for op in &ops {
+                    let before = editor.document().clone();
+                    let advertised = match op {
+                        IndentOp::More => editor.can_indent_more(),
+                        IndentOp::Less => editor.can_indent_less(),
+                    };
+                    let changed = match op {
+                        IndentOp::More => editor.indent_current_paragraph(),
+                        IndentOp::Less => editor.unindent_current_paragraph(),
+                    };
+                    applied.push((*op, changed));
+
+                    let context = || {
+                        format!(
+                            "seed: {seed_name}\nstart position: {:?}\nops applied: {applied:?}\ntree:\n{}",
+                            segment.paragraph_path,
+                            inspect::dump_tree(editor.document(), Some(&editor.cursor_pointer()))
+                        )
+                    };
+
+                    assert_eq!(
+                        changed,
+                        advertised,
+                        "can_indent_more/less disagrees with the operation outcome\n{}",
+                        context()
+                    );
+
+                    if !changed {
+                        assert_eq!(
+                            editor.document(),
+                            &before,
+                            "operation returned false but modified the document\n{}",
+                            context()
+                        );
+                    }
+
+                    let problems = structural_problems(editor.document());
+                    assert!(
+                        problems.is_empty(),
+                        "structural problems: {problems:?}\n{}",
+                        context()
+                    );
+
+                    let texts = document_texts(editor.document());
+                    assert_eq!(
+                        texts,
+                        seed_texts,
+                        "indent/unindent changed document text content\n{}",
+                        context()
+                    );
+                }
+            }
+        }
+    }
+}
+
+/// Indenting the first item of a nested list has nothing to indent into:
+/// it must be a clean no-op. (Previously it tore the item out of the nested
+/// list, leaving behind an empty list item that could not be removed.)
+#[test]
+fn indent_first_nested_list_item_is_a_noop() {
+    let initial = ftml! {
+        ul {
+            li {
+                p { "Parent" }
+                ul { li { p { "Child" } } }
+            }
+        }
+    };
+    let mut editor = DocumentEditor::new(initial.clone());
+
+    let mut path = ParagraphPath::new_root(0);
+    path.push_entry(0, 1); // nested list within the first entry
+    path.push_entry(0, 0); // "Child"
+    let pointer = CursorPointer {
+        paragraph_path: path,
+        span_path: SpanPath::new(vec![0]),
+        offset: 0,
+        segment_kind: SegmentKind::Text,
+    };
+    assert!(editor.move_to_pointer(&pointer));
+
+    let changed = editor.indent_current_paragraph();
+
+    assert_eq!(
+        editor.document(),
+        &initial,
+        "indent of the first nested item must not restructure the tree \
+         (changed={changed})\ntree:\n{}",
+        inspect::dump_tree(editor.document(), Some(&editor.cursor_pointer()))
+    );
+}
+
+/// Indenting the only item of a list into a preceding quote must not leave
+/// the now-empty list behind as an unremovable empty bullet.
+#[test]
+fn indent_single_list_item_into_quote_leaves_no_empty_list() {
+    let initial = ftml! {
+        quote { p { "Quoted" } }
+        ul { li { p { "Only" } } }
+    };
+    let mut editor = DocumentEditor::new(initial);
+
+    let pointer = pointer_to_entry_span(1, 0, 0);
+    assert!(editor.move_to_pointer(&pointer));
+    assert!(editor.indent_current_paragraph());
+
+    let expected = ftml! {
+        quote {
+            p { "Quoted" }
+            p { "Only" }
+        }
+    };
+    assert_eq!(
+        editor.document().clone(),
+        expected,
+        "tree:\n{}",
+        inspect::dump_tree(editor.document(), Some(&editor.cursor_pointer()))
+    );
+}
+
+/// The full "move a paragraph below a nested list item" flow: indenting a
+/// trailing paragraph twice should first make it a sibling list item, then
+/// a sibling of the nested item — never an empty item.
+#[test]
+fn indent_paragraph_below_nested_item_step_by_step() {
+    let initial = ftml! {
+        ul {
+            li {
+                p { "One" }
+                ul { li { p { "Two" } } }
+            }
+        }
+        p { "Para" }
+    };
+    let mut editor = DocumentEditor::new(initial);
+
+    let pointer = pointer_to_root_span(1);
+    assert!(editor.move_to_pointer(&pointer));
+
+    assert!(editor.indent_current_paragraph());
+    let after_first = ftml! {
+        ul {
+            li {
+                p { "One" }
+                ul { li { p { "Two" } } }
+            }
+            li { p { "Para" } }
+        }
+    };
+    assert_eq!(
+        editor.document().clone(),
+        after_first,
+        "after first indent\ntree:\n{}",
+        inspect::dump_tree(editor.document(), Some(&editor.cursor_pointer()))
+    );
+
+    assert!(editor.indent_current_paragraph());
+    let after_second = ftml! {
+        ul {
+            li {
+                p { "One" }
+                ul {
+                    li { p { "Two" } }
+                    li { p { "Para" } }
+                }
+            }
+        }
+    };
+    assert_eq!(
+        editor.document().clone(),
+        after_second,
+        "after second indent\ntree:\n{}",
+        inspect::dump_tree(editor.document(), Some(&editor.cursor_pointer()))
+    );
+}
+
+/// Unindenting a continuation paragraph (Ctrl-P creates one within the
+/// entry) from the middle of a list must split the list there, like
+/// unindenting an item does — not drop the paragraph below the whole list,
+/// where it seems to vanish.
+#[test]
+fn unindent_continuation_paragraph_splits_list() {
+    let initial = ftml! {
+        ul {
+            li { p { "A" } }
+            li {
+                p { "First" }
+                p { "Second" }
+            }
+            li { p { "B" } }
+        }
+    };
+    let mut editor = DocumentEditor::new(initial);
+
+    let pointer = pointer_to_entry_span(0, 1, 1); // "Second"
+    assert!(editor.move_to_pointer(&pointer));
+    assert!(editor.can_indent_less());
+    assert!(editor.unindent_current_paragraph());
+
+    let expected = ftml! {
+        ul {
+            li { p { "A" } }
+            li { p { "First" } }
+        }
+        p { "Second" }
+        ul {
+            li { p { "B" } }
+        }
+    };
+    assert_eq!(
+        editor.document().clone(),
+        expected,
+        "tree:\n{}",
+        inspect::dump_tree(editor.document(), Some(&editor.cursor_pointer()))
+    );
+    assert_eq!(editor.cursor_pointer().paragraph_path.root_index(), Some(1));
+}
+
+/// The reported flow: empty item between non-empty ones, Ctrl-P, unindent.
+/// The new paragraph must end up as an empty text paragraph splitting the
+/// list at that position, with the cursor on it.
+#[test]
+fn ctrl_p_then_unindent_on_empty_item_splits_list_in_place() {
+    let initial = ftml! {
+        ul {
+            li { p { "A" } }
+            li { p { "" } }
+            li { p { "B" } }
+        }
+    };
+    let mut editor = DocumentEditor::new(initial);
+
+    let pointer = pointer_to_entry_span(0, 1, 0); // the empty item
+    assert!(editor.move_to_pointer(&pointer));
+    assert!(editor.insert_paragraph_break_as_sibling());
+    assert!(editor.unindent_current_paragraph());
+
+    let expected = ftml! {
+        ul {
+            li { p { "A" } }
+            li { p { "" } }
+        }
+        p { "" }
+        ul {
+            li { p { "B" } }
+        }
+    };
+    assert_eq!(
+        editor.document().clone(),
+        expected,
+        "tree:\n{}",
+        inspect::dump_tree(editor.document(), Some(&editor.cursor_pointer()))
+    );
+    assert_eq!(editor.cursor_pointer().paragraph_path.root_index(), Some(1));
+}

--- a/src/snapshot_tests.rs
+++ b/src/snapshot_tests.rs
@@ -581,3 +581,54 @@ fn paste_rebuilds_cut_list_items() {
     app.ctrl('v');
     assert_svg("paste_rebuilds_cut_list_items", &mut app);
 }
+
+/// Unindenting a continuation paragraph out of the middle of a list splits
+/// the list, which changes the number of root paragraphs. The cached layout
+/// must be fully rebuilt: previously the incremental update left the screen
+/// truncated and the cursor misplaced until the cursor was moved away and
+/// back.
+#[test]
+fn unindent_split_renders_fully_with_cursor_in_place() {
+    let document = ftml! {
+        ul {
+            li { p { "Alpha" } }
+            li { p { "" } }
+            li { p { "Beta" } }
+        }
+        p { "Tail" }
+    };
+    let mut app = TestApp::new(40, 14, document);
+    app.key(KeyCode::Down); // onto the empty item
+    app.ctrl('p'); // continuation paragraph within the item
+    app.ctrl('['); // unindent: splits the list at the new paragraph
+
+    // The whole document must be on screen right away.
+    let lines = app.buffer_lines();
+    let row_of = |needle: &str| {
+        lines
+            .iter()
+            .position(|line| line.contains(needle))
+            .unwrap_or_else(|| panic!("{needle:?} not on screen: {lines:#?}"))
+    };
+    let empty_bullet_row = lines
+        .iter()
+        .position(|line| line.trim_end() == "•")
+        .expect("empty list item visible");
+    let beta_row = row_of("• Beta");
+    row_of("• Alpha");
+    row_of("Tail");
+
+    // The cursor sits on the new empty paragraph between the list halves...
+    let cursor = app.cursor_position().expect("cursor shown");
+    assert_eq!(cursor.x, 0, "cursor at start of the empty paragraph");
+    assert!(
+        (usize::from(cursor.y)) > empty_bullet_row && (usize::from(cursor.y)) < beta_row,
+        "cursor row {} not between empty item (row {empty_bullet_row}) and Beta (row {beta_row})",
+        cursor.y
+    );
+
+    // ... and moving away and back lands on exactly the same spot.
+    app.key(KeyCode::Down);
+    app.key(KeyCode::Up);
+    assert_eq!(app.cursor_position(), Some(cursor));
+}

--- a/src/test_harness.rs
+++ b/src/test_harness.rs
@@ -144,6 +144,24 @@ impl TestApp {
         }
     }
 
+    /// The terminal cursor position after the last draw.
+    pub fn cursor_position(&mut self) -> Option<Position> {
+        self.terminal.get_cursor_position().ok()
+    }
+
+    /// Plain-text contents of the terminal buffer, one string per row.
+    pub fn buffer_lines(&self) -> Vec<String> {
+        let buffer = self.terminal.backend().buffer();
+        let area = buffer.area();
+        (0..area.height)
+            .map(|y| {
+                (0..area.width)
+                    .map(|x| buffer[(x, y)].symbol())
+                    .collect::<String>()
+            })
+            .collect()
+    }
+
     /// Render the current frame to SVG.
     pub fn svg(&mut self) -> String {
         self.svg_with(CellMetrics::default())


### PR DESCRIPTION
- Changing the indent level of paragraphs near nested lists no longer leaves
  behind empty list items that could not be removed. This covered several
  cases, including indenting the first item of a nested list, indenting a sole
  list item into a preceding quote, and unindenting the only child of a quote.
- The Format menu's "Indent more" is now enabled only when indenting would
  actually do something, matching what the operation performs.
- Unindenting a paragraph from the middle of a list now splits the list at that
  spot instead of dropping the paragraph below the entire list, where it
  appeared to vanish.
- Splitting a list by unindenting now redraws the whole document immediately
  with the cursor in the right place, instead of leaving the view truncated and
  the cursor misplaced until moving away and back.